### PR TITLE
Adding support for Firefox mobile inside mozregression

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Just run the nightly for a particular date:
 Find regression range on Thunderbird nightlies:
 	mozregression --app=thunderbird
 	
+Find regression range on Firefox mobile nightlies:
+	mozregression --app=mobile
+	
 Other branches/repos:
 	mozregression --repo=mozilla-1.9.2
 	

--- a/mozregression/mozInstall.py
+++ b/mozregression/mozInstall.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
                           1.9", metavar="BRANCH")
   parser.add_option("-p", "--Product", dest="product",
                     help="Product name - optional should be all lowercase if\
-                         specified: firefox, thunderbird, etc",
+                         specified: firefox, mobile, thunderbird, etc",
                     metavar="PRODUCT")
   parser.add_option("-o", "--Operation", dest="op",
                     help="The operation you would like the script to perform.\

--- a/mozregression/regression.py
+++ b/mozregression/regression.py
@@ -106,8 +106,8 @@ def cli():
     parser.add_option("-p", "--profile", dest="profile", help="profile to use with nightlies", metavar="PATH")
     parser.add_option("-a", "--args", dest="cmdargs", help="command-line arguments to pass to the application",
                       metavar="ARG1,ARG2", default="")
-    parser.add_option("-n", "--app", dest="app", help="application name (firefox or thunderbird)",
-                      metavar="[firefox|thunderbird]", default="firefox")
+    parser.add_option("-n", "--app", dest="app", help="application name (firefox, mobile or thunderbird)",
+                      metavar="[firefox|mobile|thunderbird]", default="firefox")
     parser.add_option("-r", "--repo", dest="repo_name", help="repository name on ftp.mozilla.org",
                       metavar="[mozilla-central]", default=None)
     (options, args) = parser.parse_args()

--- a/mozregression/runnightly.py
+++ b/mozregression/runnightly.py
@@ -105,7 +105,7 @@ class Nightly(object):
                 return url
 
     def getUrl(self, date, hour):
-        url = "http://ftp.mozilla.org/pub/mozilla.org/" + self.name + "/nightly/"
+        url = "http://ftp.mozilla.org/pub/mozilla.org/" + self.appName + "/nightly/"
         year = str(date.year)
         month = self.formatDatePart(date.month)
         day = self.formatDatePart(date.day)
@@ -142,6 +142,7 @@ class Nightly(object):
             return ("", "")
 
 class ThunderbirdNightly(Nightly):
+    appName = 'thunderbird'
     name = 'thunderbird'
     profileClass = ThunderbirdProfile
                 
@@ -163,6 +164,7 @@ class ThunderbirdNightly(Nightly):
 
 
 class FirefoxNightly(Nightly):
+    appName = 'firefox'
     name = 'firefox'
     profileClass = FirefoxProfile
 
@@ -172,12 +174,21 @@ class FirefoxNightly(Nightly):
         else:
             return "mozilla-central"
 
+class FennecNightly(Nightly):
+    appName = 'mobile'
+    name = 'fennec'
+    profileClass = FirefoxProfile
+
+    def getRepoName(self, date):
+      return "mozilla-central-linux"
 
 class NightlyRunner(object):
     def __init__(self, addons=None, appname="firefox", repo_name=None,
                  profile=None, cmdargs=[]):
         if appname.lower() == 'thunderbird':
            self.app = ThunderbirdNightly(repo_name=repo_name)
+        elif appname.lower() == 'mobile':
+           self.app = FennecNightly(repo_name=repo_name)
         else:
            self.app = FirefoxNightly(repo_name=repo_name)
         self.addons = addons


### PR DESCRIPTION
Hey,
I'm one of the Front-End developer of Firefox Mobile (aka Fennec) and I would like to see a built-in support for Fennec in mozregression.
My main reason for it is because the Front-end part of Fennec lives into a separate repo (http://hg.mozilla.org/mobile-browser/) and we used features that sometimes are not enabled into the normal Firefox build (like e10s, Shadow Layers, ...)

The changes are small but we be useful.
Thanks in advance for your reply.
Vivien Nicolas [:vingtetun]
