### PR TITLE
'WindowsError: [Error 32]' from renaming the downloaded file while it's still open.

### DIFF
--- a/mozregression/utils.py
+++ b/mozregression/utils.py
@@ -54,9 +54,9 @@ def download_url(url, dest=None, message="Downloading Nightly from:"):
         f.write(chunk)
         percent = (bytes_so_far / total_size) * 100
         update_download_progress(percent)
+    f.close()
     # move the temp file to the dest
     os.rename(tmp_file, dest)
-    f.close()
 
     return dest
 


### PR DESCRIPTION
The following occurs on Windows with the --persist option.

  File "build\bdist.win32\egg\mozregression\runnightly.py", line 308, in cli
  File "build\bdist.win32\egg\mozregression\runnightly.py", line 249, in start
  File "build\bdist.win32\egg\mozregression\runnightly.py", line 242, in install

  File "build\bdist.win32\egg\mozregression\runnightly.py", line 89, in download

  File "build\bdist.win32\egg\mozregression\utils.py", line 58, in download_url
WindowsError: [Error 32] The process cannot access the file because it is being
used by another process
