### PR TITLE
Bug 935183 - Various fixes to inbound support

### DIFF
--- a/mozregression/runinbound.py
+++ b/mozregression/runinbound.py
@@ -23,7 +23,7 @@ class FirefoxInbound(FirefoxNightly):
                 return url + href
 
     def getRepoName(self, date):
-        return "mozilla-central"
+        return "mozilla-inbound"
 
 class InboundRunner(NightlyRunner):
 


### PR DESCRIPTION
Various fixes:
- Use json pushlog, not revision timestamps inside a checked out copy of m-c
  (that might not correspond with what was actually committed!)
- Display correct repository link when we've bisected all the inbounds
  we can
