### PR TITLE
bug 1031915 - fails to process ranges against old nightlies

### DIFF
--- a/mozregression/runnightly.py
+++ b/mozregression/runnightly.py
@@ -44,7 +44,7 @@ class Nightly(object):
                 print "No builds available for 64 bit Windows" \
                       " (try specifying --bits=32)"
                 sys.exit()
-            return ".*win32.zip"
+            return ".*win32.zip$"
         elif mozinfo.os == "linux":
             if bits == 64:
                 return ".*linux-x86_64.tar.bz2"


### PR DESCRIPTION
Fixes this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1031915

The regex was matching both .asc and .zip files, so I just added the `$` to mark the end of the string.
