### PR TITLE
add badges for PyPi version and travis.ci build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 mozregression is an interactive regression range finder for Mozilla nightly and inbound builds.
 
+[![PyPI version](https://badge.fury.io/py/mozregression.svg)](http://badge.fury.io/py/mozregression)
+[![Build Status](https://travis-ci.org/mozilla/mozregression.svg?branch=master)](https://travis-ci.org/mozilla/mozregression)
+
 For more information see:
 
 http://mozilla.github.io/mozregression/


### PR DESCRIPTION
This provides visual information and links to PyPi latest version and travis.ci build status. You can see the result here: https://github.com/parkouss/mozregression/tree/badges.
