### PR TITLE
Fix printing revision info twice

### DIFF
--- a/mozregression/regression.py
+++ b/mozregression/regression.py
@@ -165,8 +165,6 @@ class Bisector(object):
             self._ensure_metadata(good_date, bad_date)
             self.print_range(good_date, bad_date)
             if self.appname in ('firefox', 'fennec', 'b2g'):
-                self._ensure_metadata(good_date, bad_date)
-                self.print_range(good_date, bad_date)
                 print "... attempting to bisect inbound builds (starting " \
                     "from previous day, to make sure no inbound revision is " \
                     "missed)"


### PR DESCRIPTION
Properly applying mozilla/mozregression@f1adf45ae5d98245548d87e139e1c91e6a6d59ad, see https://bugzilla.mozilla.org/show_bug.cgi?id=1042173#c12
