### PR TITLE
Adds a new parameter "--list-releases"

### DIFF
--- a/mozregression/regression.py
+++ b/mozregression/regression.py
@@ -16,7 +16,7 @@ from mozregression import errors
 from mozregression import __version__
 from mozregression.utils import (parse_date, date_of_release, format_date,
                                  parse_bits, set_http_cache_session,
-                                 one_gigabyte)
+                                 one_gigabyte, formatted_valid_release_dates)
 from mozregression.inboundfinder import get_repo_url, BuildsFinder
 from mozregression.build_data import NightlyBuildData
 from mozregression.fetch_configs import create_config
@@ -384,6 +384,10 @@ def parse_args():
                         dest="good_date",
                         help="last known good nightly build")
 
+    parser.add_argument("--list-releases",
+                        action="store_true",
+                        help="list all known releases and exit")
+
     parser.add_argument("--bad-release",
                         type=int,
                         help=("first known bad nightly build. This option is"
@@ -459,6 +463,10 @@ def get_app():
     default_good_date = "2009-01-01"
     options = parse_args()
     logger = commandline.setup_logging("mozregression", options, {"mach": sys.stdout})
+ 
+    if options.list_releases:
+        print(formatted_valid_release_dates())
+        return
 
     fetch_config = create_config(options.app, mozinfo.os, options.bits)
 
@@ -497,7 +505,7 @@ def get_app():
             options.bad_date = date_of_release(options.bad_release)
             if options.bad_date is None:
                 sys.exit("Unable to find a matching date for release "
-                         + str(options.bad_release))
+                         + str(options.bad_release) + "\n" + formatted_valid_release_dates())
             logger.info("Using 'bad' date %s for release %s"
                         % (options.bad_date, options.bad_release))
         if not options.good_release and not options.good_date:
@@ -511,7 +519,7 @@ def get_app():
             options.good_date = date_of_release(options.good_release)
             if options.good_date is None:
                 sys.exit("Unable to find a matching date for release "
-                         + str(options.good_release))
+                         + str(options.good_release) + "\n" + formatted_valid_release_dates())
             logger.info("Using 'good' date %s for release %s"
                         % (options.good_date, options.good_release))
 

--- a/mozregression/utils.py
+++ b/mozregression/utils.py
@@ -143,7 +143,7 @@ def get_build_regex(name, os, bits, with_ext=True):
     else:
         return regex
 
-def date_of_release(release):
+def releases():
     """Provide the date of a release.
     The date is a string formated as "yyyy-mm-dd",
     and the release an integer.
@@ -180,6 +180,20 @@ def date_of_release(release):
         33: "2014-07-21",
         34: "2014-09-02",
     }
-    if release in releases:
-        return releases[release]
-    return None
+    return releases
+
+def date_of_release(release):
+    """Provide the date of a release.
+    The date is a string formated as "yyyy-mm-dd",
+    and the release an integer.
+    """
+    return releases().get(release)
+
+def formatted_valid_release_dates():
+    """Returns a formatted string (ready to be printed) representing the valid release dates.
+    """
+    message = "Valid releases: \n"
+    for key, value in releases().iteritems():
+        message += '% 3s: %s\n' % (key, value)
+
+    return message

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -113,6 +113,20 @@ class TestRelease(unittest.TestCase):
         date = utils.date_of_release(34)
         self.assertEquals(date, "2014-09-02")
 
+    def test_valid_formatted_release_dates(self):
+        formatted_output = utils.formatted_valid_release_dates()
+        firefox_releases = utils.releases()
+
+        for line in formatted_output.splitlines():
+            if "Valid releases: " in line:
+                continue
+
+            fields = line.translate(None, " ").split(":")
+            version = int(fields[0])
+            date = fields[1]
+            self.assertTrue(firefox_releases.has_key(version))
+            self.assertEquals(date, firefox_releases[version])
+
     def test_invalid_release_to_date(self):
         date = utils.date_of_release(4)
         self.assertEquals(date, None)


### PR DESCRIPTION
Add a new parameter "--list-releases" for the script regression.py, permitting to display all available firefox releases.
