### PR TITLE
"pep8 check for travis ci build on mozregression"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ python:
     - "2.7"
 
 install:
-    pip install mock coverage coveralls
+    pip install mock coverage coveralls pep8
+
+before_script:
+    pep8 mozregression tests setup.py
 
 script:
     coverage run setup.py test

--- a/mozregression/bisector.py
+++ b/mozregression/bisector.py
@@ -17,6 +17,7 @@ def compute_steps_left(steps):
         return 0
     return math.trunc(math.log(steps, 2))
 
+
 class BisectorHandler(object):
     """
     React to events of a :class:`Bisector`. This is intended to be subclassed.
@@ -127,6 +128,7 @@ class BisectorHandler(object):
     def user_exit(self, mid):
         pass
 
+
 class NightlyHandler(BisectorHandler):
     build_data_class = NightlyBuildData
     build_type = 'nightly'
@@ -138,7 +140,7 @@ class NightlyHandler(BisectorHandler):
         # register dates
         self.good_date, self.bad_date = \
             self._reverse_if_find_fix(self.build_data.get_associated_data(0),
-                                     self.build_data.get_associated_data(-1))
+                                      self.build_data.get_associated_data(-1))
 
     def build_infos(self, index):
         infos = BisectorHandler.build_infos(self, index)
@@ -199,7 +201,7 @@ class NightlyHandler(BisectorHandler):
                                                    self.bad_date)
             return ("%s/pushloghtml?startdate=%s&enddate=%s\n"
                     % (self.found_repo, start, end))
-            
+
 
 class InboundHandler(BisectorHandler):
     build_data_class = InboundBuildData
@@ -223,6 +225,7 @@ class InboundHandler(BisectorHandler):
                           % (words[0], self.good_revision))
         self._logger.info('%s known bad inbound revision: %s'
                           % (words[1], self.bad_revision))
+
 
 class Bisector(object):
     """
@@ -316,6 +319,7 @@ class Bisector(object):
                 handler.user_exit(mid)
                 return self.USER_EXIT
 
+
 class BisectRunner(object):
     def __init__(self, fetch_config, test_runner, options):
         self.fetch_config = fetch_config
@@ -337,13 +341,14 @@ class BisectRunner(object):
                 days = 6
                 too_many_attempts = False
                 first_date = min(handler.good_date, handler.bad_date)
-                while not 'changeset' in infos:
+                while 'changeset' not in infos:
                     days += 1
                     if days >= 10:
                         too_many_attempts = True
                         break
                     prev_date = first_date - datetime.timedelta(days=days)
-                    infos = handler.build_data.get_build_infos_for_date(prev_date)
+                    build_data = handler.build_data
+                    infos = build_data.get_build_infos_for_date(prev_date)
                 if days > 7 and not too_many_attempts:
                     self._logger.info("At least one build folder was"
                                       " invalid, we have to start from"
@@ -359,9 +364,9 @@ class BisectRunner(object):
                     # old nightly builds do not have the changeset information
                     # so we can't go on inbound. Anyway, these are probably too
                     # old and won't even exists on inbound.
-                    self._logger.warning("Not enough changeset information to"
-                                         " produce initial inbound regression"
-                                         " range. Builds are probably too old.")
+                    self._logger.warning("Not enough changeset information to "
+                                         "produce initial inbound regression "
+                                         "range. Builds are probably too old.")
                     return 1
                 return self.bisect_inbound(good_rev, bad_rev)
             else:

--- a/mozregression/build_data.py
+++ b/mozregression/build_data.py
@@ -11,6 +11,7 @@ from mozregression.utils import url_links, get_http_session
 
 
 class BuildData(object):
+
     """
     Represents some build data available, designed to be used in
     bisection.
@@ -108,16 +109,16 @@ class BuildData(object):
             # of 4.
             if self[0] is None:
                 self._logger.debug("We need to fetch the lower limit")
-                bound = min(size, self.half_window_range*2)
+                bound = min(size, self.half_window_range * 2)
                 range_min.extend(range(0, bound))
             if self[-1] is None:
                 self._logger.debug("We need to fetch the higher limit")
-                bound = max(0, size - self.half_window_range*2)
+                bound = max(0, size - self.half_window_range * 2)
                 range_max.extend(range(bound, size))
 
             # restrict the number of builds to fetch
             range_to_update = set(range_min + range_max)
-            while len(range_to_update) > self.half_window_range*2:
+            while len(range_to_update) > self.half_window_range * 2:
                 if len(range_min) > len(range_max):
                     range_min = range_min[:-1]
                 else:
@@ -174,7 +175,8 @@ class BuildData(object):
         nb_try = 0
         while builds_to_get:
             nb_try += 1
-            with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            with futures.ThreadPoolExecutor(max_workers=max_workers) \
+                    as executor:
                 futures_results = {}
                 for i in builds_to_get:
                     future = self._create_fetch_task(executor, i)
@@ -186,7 +188,8 @@ class BuildData(object):
                         must_raise = True
                         if isinstance(exc, requests.HTTPError):
                             if nb_try < max_try:
-                                self._logger.warning("Got HTTPError - retrying")
+                                self._logger.warning(
+                                    "Got HTTPError - retrying")
                                 self._logger.warning(exc)
                                 must_raise = False
                         if must_raise:
@@ -201,12 +204,16 @@ class BuildData(object):
         self._logger.debug("Now we got %d folders - %d were bad"
                            % (len(self), size - len(self)))
 
+
 class BuildFolderInfoFetcher(object):
     """
     Allow to retrieve information from build folders.
 
-    :param build_regex: a regexp or string regexp that can match the build file.
-    :param build_info_regex: a regexp or string regexp that can match the build
+    :param build_regex: a regexp or string regexp that
+        match the build file.
+
+    :param build_info_regex: a regexp or string regexp
+        that can match the build
                              info file (.txt).
     """
     def __init__(self, build_regex, build_info_regex):
@@ -231,9 +238,10 @@ class BuildFolderInfoFetcher(object):
         if not url.endswith('/'):
             url += '/'
         for link in url_links(url):
-            if not 'build_url' in data and self.build_regex.match(link):
+            if 'build_url' not in data and self.build_regex.match(link):
                 data['build_url'] = url + link
-            elif not 'build_txt_url' in data and self.build_info_regex.match(link):
+            elif 'build_txt_url' not in data  \
+                    and self.build_info_regex.match(link):
                 data['build_txt_url'] = url + link
 
         if read_txt_content and 'build_txt_url' in data:
@@ -264,6 +272,7 @@ class BuildFolderInfoFetcher(object):
             if matched:
                 data['changeset'] = matched.group(1)
         return data
+
 
 class MozBuildData(BuildData):
     """
@@ -344,7 +353,7 @@ class InboundBuildData(MozBuildData):
     """
     Fetch build information for all builds between start_rev and end_rev.
     """
-    def __init__(self, fetch_config, start_rev, end_rev, range=60*60*4):
+    def __init__(self, fetch_config, start_rev, end_rev, range=60 * 60 * 4):
         MozBuildData.__init__(self, [], None)
         self.fetch_config = fetch_config
         self.raw_revisions = []
@@ -428,6 +437,7 @@ class InboundBuildData(MozBuildData):
                     return True
         return False
 
+
 class NightlyUrlBuilder(object):
     """
     Build a url for a nightly build folder for a given instance of
@@ -504,11 +514,13 @@ class NightlyBuildData(MozBuildData):
         max_workers = 2
         while build_urls:
             some = build_urls[:max_workers]
-            with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            with futures.ThreadPoolExecutor(max_workers=max_workers) \
+                    as executor:
                 futures_results = {}
                 valid_builds = []
                 for i, url in enumerate(some):
-                    future = executor.submit(self.info_fetcher.find_build_info, url)
+                    future = executor.submit(
+                        self.info_fetcher.find_build_info, url)
                     futures_results[future] = i
                 for future in futures.as_completed(futures_results):
                     i = futures_results[future]
@@ -520,7 +532,8 @@ class NightlyBuildData(MozBuildData):
                     build_infos = valid_builds[0][1]
                     if 'build_txt_url' in build_infos:
                         txt_url = build_infos['build_txt_url']
-                        txt_infos = self.info_fetcher.find_build_info_txt(txt_url)
+                        txt_infos = self.info_fetcher.find_build_info_txt(
+                            txt_url)
                         build_infos.update(txt_infos)
                     return build_infos
             build_urls = build_urls[max_workers:]
@@ -533,7 +546,7 @@ class NightlyBuildData(MozBuildData):
         # nightly builds are not often broken. There are good chances
         # that trying to fetch mid point and limits at the same time
         # will gives us enough information. This will save time in most cases.
-        self._fetch(set([0, size/2, size-1]))
+        self._fetch(set([0, size / 2, size - 1]))
         return MozBuildData.mid_point(self)
 
     def get_build_infos_for_date(self, date):

--- a/mozregression/errors.py
+++ b/mozregression/errors.py
@@ -59,6 +59,7 @@ class TestCommandError(MozRegressionError):
     Raised on a user test command error.
     """
 
+
 class UnavailableRelease(MozRegressionError):
     """
     Raised when firefox release is not available.

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -8,13 +8,16 @@ import copy
 from mozregression.utils import get_build_regex, ClassRegistry
 from mozregression import errors
 
+
 class CommonConfig(object):
     """
     Define the configuration for both nightly and inbound fetching.
 
     :attr name: the name of the application
     """
+
     app_name = None
+
     def __init__(self, os, bits):
         self.os = os
         self.bits = bits
@@ -44,6 +47,7 @@ class CommonConfig(object):
         Returns True if the configuration can be used for inbound fetching.
         """
         return isinstance(self, InboundConfigMixin)
+
 
 class NightlyConfigMixin(object):
     """
@@ -107,12 +111,14 @@ class NightlyConfigMixin(object):
         # we can go on inbound if no nightly repo has been specified.
         return self.is_inbound() and not self.nightly_repo
 
+
 class FireFoxNightlyConfigMixin(NightlyConfigMixin):
     def _get_nightly_repo(self, date):
         if date < datetime.date(2008, 6, 17):
             return "trunk"
         else:
             return "mozilla-central"
+
 
 class ThunderbirdNightlyConfigMixin(NightlyConfigMixin):
     nightly_base_repo_name = 'thunderbird'
@@ -132,11 +138,13 @@ class ThunderbirdNightlyConfigMixin(NightlyConfigMixin):
         else:
             return "comm-central"
 
+
 class B2GNightlyConfigMixin(NightlyConfigMixin):
     nightly_base_repo_name = 'b2g'
 
     def _get_nightly_repo(self, date):
         return "mozilla-central"
+
 
 class FennecNightlyConfigMixin(NightlyConfigMixin):
     nightly_base_repo_name = "mobile"
@@ -148,17 +156,20 @@ class FennecNightlyConfigMixin(NightlyConfigMixin):
             return "mozilla-central-android-api-10"
         return "mozilla-central-android-api-11"
 
+
 class InboundConfigMixin(object):
     """
     Define the inbound-related required configuration.
     """
     inbound_branch = 'mozilla-inbound'
+
     def set_inbound_branch(self, inbound_branch):
         if inbound_branch:
             self.inbound_branch = inbound_branch
 
     def inbound_base_urls(self):
         raise NotImplementedError
+
 
 class FirefoxInboundConfigMixin(InboundConfigMixin):
     build_base_os_part = {
@@ -174,16 +185,21 @@ class FirefoxInboundConfigMixin(InboundConfigMixin):
                 % (self.inbound_branch,
                    self.build_base_os_part[self.os][self.bits])]
 
+
 class B2GInboundConfigMixin(FirefoxInboundConfigMixin):
     inbound_branch = 'b2g-inbound'
-    build_base_os_part = copy.deepcopy(FirefoxInboundConfigMixin.build_base_os_part)
+    build_base_os_part = copy.deepcopy(
+        FirefoxInboundConfigMixin.build_base_os_part
+        )
     build_base_os_part['linux'][32] = 'linux32'
 
     root_build_base_url = ('http://ftp.mozilla.org/pub/mozilla.org/b2g'
                            '/tinderbox-builds/%s-%s_gecko/')
 
+
 class FennecInboundConfigMixin(InboundConfigMixin):
     inbound_branchs = ['mozilla-inbound-android']
+
     def inbound_base_urls(self):
         return ["http://inbound-archive.pub.build.mozilla.org/pub/mozilla.org"
                 "/mobile/tinderbox-builds/%s/" % inbound_branch
@@ -197,11 +213,13 @@ class FennecInboundConfigMixin(InboundConfigMixin):
 
 REGISTRY = ClassRegistry('app_name')
 
+
 def create_config(name, os, bits):
     """
     Create and returns a configuration for the given name.
     """
     return REGISTRY.get(name)(os, bits)
+
 
 @REGISTRY.register('firefox')
 class FirefoxConfig(CommonConfig,
@@ -209,16 +227,19 @@ class FirefoxConfig(CommonConfig,
                     FirefoxInboundConfigMixin):
     pass
 
+
 @REGISTRY.register('thunderbird')
 class ThunderbirdConfig(CommonConfig,
                         ThunderbirdNightlyConfigMixin):
     pass
+
 
 @REGISTRY.register('b2g')
 class B2GConfig(CommonConfig,
                 B2GNightlyConfigMixin,
                 B2GInboundConfigMixin):
     pass
+
 
 @REGISTRY.register('fennec')
 class FennecConfig(CommonConfig,
@@ -227,11 +248,13 @@ class FennecConfig(CommonConfig,
     inbound_branchs = (FennecInboundConfigMixin.inbound_branchs
                        + ['mozilla-inbound-android-api-10',
                           'mozilla-inbound-android-api-11'])
+
     def build_regex(self):
         return r'fennec-.*\.apk'
 
     def build_info_regex(self):
         return r'fennec-.*\.txt'
+
 
 @REGISTRY.register('fennec-2.3', attr_value='fennec')
 class Fennec23Config(FennecConfig):

--- a/mozregression/limitedfilecache.py
+++ b/mozregression/limitedfilecache.py
@@ -11,6 +11,7 @@ from cachecontrol.caches import FileCache
 
 ONE_GIGABYTE = 1000000000
 
+
 def get_cache(directory, max_bytes, logger):
     forever = True if directory else False
     if forever:
@@ -21,9 +22,10 @@ def get_cache(directory, max_bytes, logger):
         # not forever so just cache within this run
         return CacheControl(requests.session())
 
+
 class LimitedFileCache(FileCache):
     def __init__(self, directory, forever=False, filemode=0o0600,
-        dirmode=0o0700, max_bytes=ONE_GIGABYTE, logger=warnings):
+                 dirmode=0o0700, max_bytes=ONE_GIGABYTE, logger=warnings):
         FileCache.__init__(self, directory, forever, filemode, dirmode)
         self.max_bytes = max_bytes
         self.curr_bytes = 0

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -124,9 +124,9 @@ def parse_args(argv=None):
 
     parser.add_argument("-c", "--command",
                         help=("Test command to evaluate builds automatically."
-                              " A return code of 0 will evaluate build as good,"
-                              " any other value will evaluate the build as"
-                              " bad."))
+                              " A return code of 0 will evaluate build as"
+                              " good, any other value will evaluate the build"
+                              " as bad."))
 
     parser.add_argument("--persist",
                         help=("the directory in which downloaded files are"
@@ -159,6 +159,7 @@ def bisect_inbound(runner, logger):
                                  " and --bad-rev must be set")
     return runner.bisect_inbound(options.last_good_revision,
                                  options.first_bad_revision)
+
 
 def bisect_nightlies(runner, logger):
     default_bad_date = str(datetime.date.today())

--- a/mozregression/utils.py
+++ b/mozregression/utils.py
@@ -76,6 +76,7 @@ def set_http_cache_session(cache_session, get_defaults=None):
         # monkey patch to set default values to a session.get calls
         # I don't see other ways to do this globally for timeout for example
         _get = cache_session.get
+
         def _default_get(*args, **kwargs):
             for k, v in get_defaults.iteritems():
                 kwargs.setdefault(k, v)
@@ -246,6 +247,9 @@ def releases():
         32: "2014-06-09",
         33: "2014-07-21",
         34: "2014-09-02",
+        35: "2014-10-13",
+        36: "2014-11-28",
+        37: "2015-01-12"
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ if sys.version_info < (2, 7) or sys.version_info > (3, 0):
 
 desc = """Regression range finder for Mozilla nightly builds"""
 long_desc = """Interactive regression range finder for Mozilla nightly builds.
-
-For more information see the mozregression website: http://mozilla.github.io/mozregression/"""
+For more information see the mozregression website:
+http://mozilla.github.io/mozregression/"""
 
 setup(name="mozregression",
       version=__version__,
@@ -24,26 +24,28 @@ setup(name="mozregression",
           [console_scripts]
           mozregression = mozregression.main:cli
         """,
-      platforms =['Any'],
-      install_requires = ['mozfile >= 0.1',
-                          'mozprofile >= 0.4',
-                          'mozrunner >= 6.5',
-                          'BeautifulSoup >= 3.0.4',
-                          'mozinstall >= 1.4',
-                          'mozinfo >= 0.4',
-                          'mozlog >= 2.7',
-                          'mozversion >= 1.1',
-                          'requests >= 2.5.0',
-                          'cachecontrol >= 0.10.2',
-                          'lockfile >= 0.10.2', # used in conjunction with cachecontrol
-                          'futures >= 2.1.6',
-                          'mozdevice >= 0.43'
-                          ],
+      platforms=['Any'],
+      install_requires=[
+          'mozfile >= 0.1',
+          'mozprofile >= 0.4',
+          'mozrunner >= 6.5',
+          'BeautifulSoup >= 3.0.4',
+          'mozinstall >= 1.4',
+          'mozinfo >= 0.4',
+          'mozlog >= 2.7',
+          'mozversion >= 1.1',
+          'requests >= 2.5.0',
+          'cachecontrol >= 0.10.2',
+          # used in conjunction with cachecontrol
+          'lockfile >= 0.10.2',
+          'futures >= 2.1.6',
+          'mozdevice >= 0.43'
+      ],
       tests_require=['mock'],
       test_suite='tests',
       classifiers=['Development Status :: 4 - Beta',
                    'Environment :: Console',
                    'Intended Audience :: Developers',
                    'Operating System :: OS Independent'
-                  ]
-     )
+                   ]
+      )

--- a/tests/unit/test_bisector.py
+++ b/tests/unit/test_bisector.py
@@ -14,6 +14,7 @@ from mozregression.bisector import (BisectorHandler, NightlyHandler,
 from mozregression.main import parse_args
 from mozregression import build_data
 
+
 class TestBisectorHandler(unittest.TestCase):
     def setUp(self):
         self.handler = BisectorHandler()
@@ -37,14 +38,15 @@ class TestBisectorHandler(unittest.TestCase):
         self.handler.good_revision = '2'
         self.handler.bad_revision = '6'
         self.assertEqual(self.handler.get_pushlog_url(),
-                         "https://hg.mozilla.repo/pushloghtml?fromchange=2&tochange=6")
+                         "https://hg.mozilla.repo/pushloghtml?\
+fromchange=2&tochange=6")
 
     def test_print_range(self):
         self.handler.found_repo = 'https://hg.mozilla.repo'
         self.handler.good_revision = '2'
         self.handler.bad_revision = '6'
         log = []
-        self.handler._logger = Mock(info = log.append)
+        self.handler._logger = Mock(info=log.append)
 
         self.handler.print_range()
         self.assertEqual(log[0], "Last good revision: 2")
@@ -53,14 +55,18 @@ class TestBisectorHandler(unittest.TestCase):
 
     @patch('mozregression.bisector.BisectorHandler._print_progress')
     def test_build_good(self, _print_progress):
-        self.handler.build_good(0, [{"changeset": '123'}, {"changeset": '456'}])
-        _print_progress.assert_called_with([{"changeset": '123'}, {"changeset": '456'}])
+        self.handler.build_good(0, [{"changeset": '123'},
+                                    {"changeset": '456'}])
+        _print_progress.assert_called_with([{"changeset": '123'},
+                                            {"changeset": '456'}])
 
     @patch('mozregression.bisector.BisectorHandler._print_progress')
     def test_build_bad(self, _print_progress):
         # with at least two, _print_progress will be called
         self.handler.build_bad(0, [{"changeset": '123'}, {"changeset": '456'}])
-        _print_progress.assert_called_with([{"changeset": '123'}, {"changeset": '456'}])
+        _print_progress.assert_called_with([{"changeset": '123'},
+                                            {"changeset": '456'}])
+
 
 class TestNightlyHandler(unittest.TestCase):
     def setUp(self):
@@ -91,9 +97,10 @@ class TestNightlyHandler(unittest.TestCase):
 
     def test_print_progress(self):
         log = []
-        self.handler._logger = Mock(info = log.append)
+        self.handler._logger = Mock(info=log.append)
         self.handler.good_date = datetime.date(2014, 11, 10)
         self.handler.bad_date = datetime.date(2014, 11, 20)
+
         def get_associated_data(index):
             if index == 0:
                 return datetime.date(2014, 11, 15)
@@ -108,7 +115,7 @@ class TestNightlyHandler(unittest.TestCase):
 
     def test_user_exit(self):
         log = []
-        self.handler._logger = Mock(info = log.append)
+        self.handler._logger = Mock(info=log.append)
         self.handler.good_date = datetime.date(2014, 11, 10)
         self.handler.bad_date = datetime.date(2014, 11, 20)
         self.handler.user_exit(0)
@@ -147,7 +154,9 @@ class TestNightlyHandler(unittest.TestCase):
         self.handler.print_range()
         self.assertEqual('Newest known good nightly: 2014-11-10', log[0])
         self.assertEqual('Oldest known bad nightly: 2014-11-20', log[1])
-        self.assertIn("pushloghtml?startdate=2014-11-10&enddate=2014-11-20", log[2])
+        self.assertIn("pushloghtml?startdate=2014-11-10&enddate=2014-11-20",
+                      log[2])
+
 
 class TestInboundHandler(unittest.TestCase):
     def setUp(self):
@@ -164,12 +173,12 @@ class TestInboundHandler(unittest.TestCase):
 
     def test_print_progress(self):
         log = []
-        self.handler._logger = Mock(info = log.append)
+        self.handler._logger = Mock(info=log.append)
         self.handler.set_build_data([
-            {'revision':'12'},
-            {'revision':'123'},
-            {'revision':'1234'},
-            {'revision':'12345'},
+            {'revision': '12'},
+            {'revision': '123'},
+            {'revision': '1234'},
+            {'revision': '12345'},
         ])
         new_data = [{'revision': '1234'}, {'revision': '12345'}]
 
@@ -180,12 +189,13 @@ class TestInboundHandler(unittest.TestCase):
 
     def test_user_exit(self):
         log = []
-        self.handler._logger = Mock(info = log.append)
+        self.handler._logger = Mock(info=log.append)
         self.handler.good_revision = '3'
         self.handler.bad_revision = '1'
         self.handler.user_exit(0)
         self.assertEqual('Newest known good inbound revision: 3', log[0])
         self.assertEqual('Oldest known bad inbound revision: 1', log[1])
+
 
 class MyBuildData(build_data.BuildData):
     def __init__(self, data=()):
@@ -194,7 +204,8 @@ class MyBuildData(build_data.BuildData):
         class MyDict(dict):
             def setdefault(self, key, value):
                 pass
-        build_data.BuildData.__init__(self, [MyDict({v:v}) for v in data])
+
+        build_data.BuildData.__init__(self, [MyDict({v: v}) for v in data])
 
     def _create_fetch_task(self, executor, i):
         ad = self.get_associated_data(i)
@@ -213,6 +224,7 @@ class MyBuildData(build_data.BuildData):
         # when there associated_data are equals.
         return [self.get_associated_data(i) for i in range(len(self))] \
             == [other.get_associated_data(i) for i in range(len(other))]
+
 
 class TestBisector(unittest.TestCase):
     def setUp(self):
@@ -240,6 +252,7 @@ class TestBisector(unittest.TestCase):
 
     def do__bisect(self, build_data, verdicts):
         iter_verdict = iter(verdicts)
+
         def evaluate(build_info, allow_back=False):
             return iter_verdict.next(), {
                 'application_changeset': 'unused',
@@ -284,7 +297,8 @@ class TestBisector(unittest.TestCase):
         ])
         # ensure that we called the handler's methods
         self.assertEqual(self.handler.initialize.mock_calls, [call()]*3)
-        self.handler.build_good.assert_called_once_with(2, MyBuildData([1, 2, 3]))
+        self.handler.build_good. \
+            assert_called_once_with(2, MyBuildData([1, 2, 3]))
         self.handler.build_bad.assert_called_once_with(1, MyBuildData([2, 3]))
         # bisection is finished
         self.assertEqual(test_result['result'], Bisector.FINISHED)
@@ -309,7 +323,8 @@ class TestBisector(unittest.TestCase):
         self.assertEqual(test_result['result'], Bisector.FINISHED)
 
     def test__bisect_with_back(self):
-        test_result = self.do__bisect(MyBuildData([1, 2, 3, 4, 5]), ['g', 'back', 'b', 'g'])
+        test_result = self.do__bisect(MyBuildData([1, 2, 3, 4, 5]),
+                                      ['g', 'back', 'b', 'g'])
         # check that set_build_data was called
         self.handler.set_build_data.assert_has_calls([
             # first call
@@ -329,7 +344,8 @@ class TestBisector(unittest.TestCase):
     def test__bisect_user_exit(self):
         test_result = self.do__bisect(MyBuildData(range(20)), ['e'])
         # check that set_build_data was called
-        self.handler.set_build_data.assert_has_calls([call(MyBuildData(range(20)))])
+        self.handler.set_build_data.\
+            assert_has_calls([call(MyBuildData(range(20)))])
         # ensure that we called the handler's method
         self.handler.initialize.assert_called_once_with()
         self.handler.user_exit.assert_called_with(10)
@@ -360,6 +376,7 @@ class TestBisector(unittest.TestCase):
                                             'b', 'g', s=1)
         _bisect.assert_called_with(self.handler, build_data)
 
+
 class TestBisectRunner(unittest.TestCase):
     @patch('mozregression.bisector.get_default_logger')
     def setUp(self, get_default_logger):
@@ -368,7 +385,9 @@ class TestBisectRunner(unittest.TestCase):
         self.logger = Mock()
         self.logs = []
         get_default_logger.return_value = Mock(info=self.logs.append)
-        self.brunner = BisectRunner(self.fetch_config, self.test_runner, parse_args([]))
+        self.brunner = BisectRunner(self.fetch_config,
+                                    self.test_runner,
+                                    parse_args([]))
 
     def test_create(self):
         self.assertIsInstance(self.brunner.bisector, Bisector)

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -4,6 +4,7 @@ import re
 
 from mozregression.fetch_configs import (FirefoxConfig, create_config, errors)
 
+
 class TestFirefoxConfigLinux64(unittest.TestCase):
     app_name = 'firefox'
     os = 'linux'
@@ -35,22 +36,28 @@ class TestFirefoxConfigLinux64(unittest.TestCase):
         self.assertEqual(self.conf.build_info_regex(), self.build_info_regex)
 
     def test_get_nighly_base_url(self):
-        base_url = self.conf.get_nighly_base_url(datetime.date(2008, 6, 27))
-        self.assertEqual(base_url, 'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/2008/06/')
+        base_url = self.conf.get_nighly_base_url(datetime.date(2008,
+                                                               6, 27))
+        self.assertEqual(base_url, 'http://ftp.mozilla.org/pub/mozilla.org/\
+firefox/nightly/2008/06/')
 
     def test_nightly_repo_regex(self):
-        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008, 6, 15))
+        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008,
+                                                                    6, 15))
         self.assertEqual(repo_regex, '^2008-06-15-[\\d-]+trunk/$')
-        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008, 6, 27))
+        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008,
+                                                                    6, 27))
         self.assertEqual(repo_regex, '^2008-06-27-[\\d-]+mozilla-central/$')
 
     def test_set_nightly_repo(self):
         self.conf.set_nightly_repo('foo-bar')
-        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008, 6, 27))
+        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008,
+                                                                    6, 27))
         self.assertEqual(repo_regex, '^2008-06-27-[\\d-]+foo-bar/$')
         # with a value of None, default is applied
         self.conf.set_nightly_repo(None)
-        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008, 6, 27))
+        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008,
+                                                                    6, 27))
         self.assertEqual(repo_regex, '^2008-06-27-[\\d-]+mozilla-central/$')
 
     def test_can_go_inbound(self):
@@ -60,8 +67,9 @@ class TestFirefoxConfigLinux64(unittest.TestCase):
         self.assertFalse(self.conf.can_go_inbound())
 
     def test_inbound_base_urls(self):
-        inbound_base_url = '%s/mozilla-inbound-%s/' % (self.base_inbound_url,
-                                                       self.base_inbound_url_ext)
+        inbound_base_url = '%s/mozilla-inbound-%s/' % \
+            (self.base_inbound_url, self.base_inbound_url_ext)
+
         self.assertEqual(self.conf.inbound_base_urls(), [inbound_base_url])
 
     def test_custom_inbound_base_urls(self):
@@ -70,11 +78,13 @@ class TestFirefoxConfigLinux64(unittest.TestCase):
                                               self.base_inbound_url_ext)
         self.assertEqual(self.conf.inbound_base_urls(), [inbound_base_url])
 
+
 class TestFirefoxConfigLinux32(TestFirefoxConfigLinux64):
     bits = 32
     build_regex = r'firefox.*linux-i686\.tar.bz2$'
     build_info_regex = r'firefox.*linux-i686\.txt$'
     base_inbound_url_ext = 'linux'
+
 
 class TestFirefoxConfigWin64(TestFirefoxConfigLinux64):
     os = 'win'
@@ -82,11 +92,13 @@ class TestFirefoxConfigWin64(TestFirefoxConfigLinux64):
     build_info_regex = r'firefox.*win64-x86_64\.txt$'
     base_inbound_url_ext = 'win64'
 
+
 class TestFirefoxConfigWin32(TestFirefoxConfigWin64):
     bits = 32
     build_regex = r'firefox.*win32\.zip$'
     build_info_regex = r'firefox.*win32\.txt$'
     base_inbound_url_ext = 'win32'
+
 
 class TestFirefoxConfigMac(TestFirefoxConfigLinux64):
     os = 'mac'
@@ -94,48 +106,62 @@ class TestFirefoxConfigMac(TestFirefoxConfigLinux64):
     build_info_regex = r'firefox.*mac.*\.txt$'
     base_inbound_url_ext = 'macosx64'
 
+
 class TestThunderbirdConfig(unittest.TestCase):
     os = 'linux'
     bits = 64
+
     def setUp(self):
         self.conf = create_config('thunderbird', self.os, self.bits)
 
     def test_nightly_repo_regex_before_2008_07_26(self):
-        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008, 7, 25))
+        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008,
+                                                                    7, 25))
         self.assertEqual(repo_regex, '^2008-07-25-[\\d-]+trunk/$')
 
     def test_nightly_repo_regex_before_2009_01_09(self):
-        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2009, 1, 8))
+        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2009,
+                                                                    1, 8))
         self.assertEqual(repo_regex, '^2009-01-08-[\\d-]+comm-central/$')
 
     def test_nightly_repo_regex_before_2010_08_21(self):
-        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2010, 8, 20))
+        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2010,
+                                                                    8, 20))
         self.assertEqual(repo_regex, '^2010-08-20-[\\d-]+comm-central-trunk/$')
 
     def test_nightly_repo_regex_since_2010_08_21(self):
-        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2010, 8, 21))
+        repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2010,
+                                                                    8, 21))
         self.assertEqual(repo_regex, '^2010-08-21-[\\d-]+comm-central/$')
+
 
 class TestThunderbirdConfigWin(TestThunderbirdConfig):
     os = 'win'
+
     def test_nightly_repo_regex_before_2008_07_26(self):
         with self.assertRaises(errors.WinTooOldBuildError):
-            TestThunderbirdConfig.test_nightly_repo_regex_before_2008_07_26(self)
+            TestThunderbirdConfig.\
+                test_nightly_repo_regex_before_2008_07_26(self)
 
     def test_nightly_repo_regex_before_2009_01_09(self):
         with self.assertRaises(errors.WinTooOldBuildError):
-            TestThunderbirdConfig.test_nightly_repo_regex_before_2009_01_09(self)
+            TestThunderbirdConfig.\
+                test_nightly_repo_regex_before_2009_01_09(self)
+
 
 class TestFennecConfig(unittest.TestCase):
     def setUp(self):
         self.conf = create_config('fennec', 'linux', 64)
 
     def test_get_nightly_repo(self):
-        repo = self.conf.get_nightly_repo(datetime.date(2014, 12, 5))
+        repo = self.conf.get_nightly_repo(datetime.date(2014,
+                                                        12, 5))
         self.assertEqual(repo, "mozilla-central-android")
-        repo = self.conf.get_nightly_repo(datetime.date(2014, 12, 10))
+        repo = self.conf.get_nightly_repo(datetime.date(2014,
+                                                        12, 10))
         self.assertEqual(repo, "mozilla-central-android-api-10")
-        repo = self.conf.get_nightly_repo(datetime.date(2015, 1, 1))
+        repo = self.conf.get_nightly_repo(datetime.date(2015,
+                                                        1, 1))
         self.assertEqual(repo, "mozilla-central-android-api-11")
 
     def test_build_regex(self):
@@ -147,7 +173,8 @@ class TestFennecConfig(unittest.TestCase):
         self.assertTrue(regex.match('fennec-36.0a1.multi.android-arm.txt'))
 
     def test_inbound_base_url(self):
-        expected = ["http://inbound-archive.pub.build.mozilla.org/pub/mozilla.org"
+        expected = ["http://inbound-archive.pub.build.mozilla.org\
+/pub/mozilla.org"
                     "/mobile/tinderbox-builds/%s/" % inbound_branch
                     for inbound_branch in ('mozilla-inbound-android',
                                            'mozilla-inbound-android-api-10',
@@ -161,9 +188,11 @@ class TestFennecConfig(unittest.TestCase):
 
         # valid inbound_branch will
         self.conf.set_inbound_branch('my')
-        expected = ["http://inbound-archive.pub.build.mozilla.org/pub/mozilla.org"
+        expected = ["http://inbound-archive.pub.build.mozilla.org/\
+pub/mozilla.org"
                     "/mobile/tinderbox-builds/my/"]
         self.assertEqual(self.conf.inbound_base_urls(), expected)
+
 
 class TestFennec23Config(unittest.TestCase):
     def setUp(self):
@@ -177,6 +206,7 @@ class TestFennec23Config(unittest.TestCase):
         self.assertEqual(repo, "mozilla-central-android")
         repo = self.conf.get_nightly_repo(datetime.date(2015, 1, 1))
         self.assertEqual(repo, "mozilla-central-android-api-9")
+
 
 class TestB2GConfig(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -7,6 +7,7 @@ from mock import patch, Mock
 from mozprofile import FirefoxProfile, Profile
 from mozregression.errors import LauncherNotRunnable
 
+
 class MyLauncher(launchers.Launcher):
     installed = None
     started = False
@@ -20,6 +21,7 @@ class MyLauncher(launchers.Launcher):
 
     def _stop(self):
         self.stopped = True
+
 
 class TestLauncher(unittest.TestCase):
     def setUp(self):
@@ -63,7 +65,10 @@ class TestLauncher(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_dest))
 
     def test_reuse_persist_file_on_create(self):
-        launcher = MyLauncher('http://foo/persist.zip', persist=self.tempdir, persist_prefix='123-')
+        launcher = MyLauncher('http://foo/persist.zip',
+                              persist=self.tempdir,
+                              persist_prefix='123-')
+
         expected_dest = os.path.join(self.tempdir, '123-persist.zip')
         # file is installed
         self.assertEqual(launcher.installed, expected_dest)
@@ -71,19 +76,22 @@ class TestLauncher(unittest.TestCase):
         self.assertTrue(os.path.exists('123-persist.zip'))
 
     def test_start_stop(self):
-        launcher = MyLauncher('http://foo/persist.zip', persist=self.tempdir, persist_prefix='123-')
+        launcher = MyLauncher('http://foo/persist.zip',
+                              persist=self.tempdir,
+                              persist_prefix='123-')
         self.assertFalse(launcher.started)
         launcher.start()
         # now it has been started
         self.assertTrue(launcher.started)
         # restarting won't do anything because it was not stopped
-        launcher.started=False
+        launcher.started = False
         launcher.start()
         self.assertFalse(launcher.started)
         # stop it, then start it again, this time _start is called again
         launcher.stop()
         launcher.start()
         self.assertTrue(launcher.started)
+
 
 class TestMozRunnerLauncher(unittest.TestCase):
     @patch('mozregression.launchers.mozinstall')
@@ -94,7 +102,8 @@ class TestMozRunnerLauncher(unittest.TestCase):
         self.launcher = launchers.MozRunnerLauncher('http://binary')
 
     # patch profile_class else we will have some temporary dirs not deleted
-    @patch('mozregression.launchers.MozRunnerLauncher.profile_class', spec=Profile)
+    @patch('mozregression.launchers.MozRunnerLauncher.\
+profile_class', spec=Profile)
     def launcher_start(self, profile_class, *args, **kwargs):
         self.profile_class = profile_class
         self.launcher.start(*args, **kwargs)
@@ -109,7 +118,8 @@ class TestMozRunnerLauncher(unittest.TestCase):
 
         self.assertEqual(kwargs['cmdargs'], ())
         self.assertEqual(kwargs['binary'], '/binary')
-        self.assertEqual(kwargs['process_args'], {'processOutputLine': [self.launcher._logger.debug]})
+        self.assertEqual(kwargs['process_args'],
+                         {'processOutputLine': [self.launcher._logger.debug]})
         self.assertIsInstance(kwargs['profile'], Profile)
         # runner is started
         self.launcher.runner.start.assert_called_once_with()
@@ -147,6 +157,7 @@ class TestMozRunnerLauncher(unittest.TestCase):
         del self.launcher
         self.assertFalse(os.path.isdir(tempdir))
 
+
 class TestFennecLauncher(unittest.TestCase):
     @patch('mozregression.launchers.download_url')
     @patch('mozregression.launchers.os.unlink')
@@ -183,13 +194,16 @@ class TestFennecLauncher(unittest.TestCase):
 
         # exception raised if answer is not 'y'
         raw_input.return_value = 'n'
-        self.assertRaises(LauncherNotRunnable, launchers.FennecLauncher.check_is_runnable)
+        self.assertRaises(LauncherNotRunnable,
+                          launchers.FennecLauncher.check_is_runnable)
 
         # exception raised if there is no device
         raw_input.return_value = 'y'
         devices.return_value = False
-        self.assertRaises(LauncherNotRunnable, launchers.FennecLauncher.check_is_runnable)
+        self.assertRaises(LauncherNotRunnable,
+                          launchers.FennecLauncher.check_is_runnable)
 
         # or if ADBHost().devices() raise an unexpected IOError
         devices.side_effect = OSError()
-        self.assertRaises(LauncherNotRunnable, launchers.FennecLauncher.check_is_runnable)
+        self.assertRaises(LauncherNotRunnable,
+                          launchers.FennecLauncher.check_is_runnable)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -11,6 +11,7 @@ import datetime
 from mozregression import main, utils, errors
 from mozregression.test_runner import CommandTestRunner
 
+
 class TestMainCli(unittest.TestCase):
     def setUp(self):
         self.runner = Mock()
@@ -48,9 +49,11 @@ class TestMainCli(unittest.TestCase):
         self.runner.bisect_nightlies.return_value = 0
         exitcode = self.do_cli([])
         # application is by default firefox
-        self.assertEqual(self.runner.fetch_config.app_name, 'firefox')
+        self.assertEqual(self.runner.fetch_config.app_name,
+                         'firefox')
         # bisect_nightlies has been called
-        self.runner.bisect_nightlies.assert_called_with(datetime.date(2009, 1, 1),
+        self.runner.bisect_nightlies.assert_called_with(datetime.date(2009,
+                                                                      1, 1),
                                                         datetime.date.today())
         # we exited with the return value of bisect_nightlies
         self.assertEquals(exitcode, 0)
@@ -111,12 +114,14 @@ class TestMainCli(unittest.TestCase):
 
     def test_handle_mozregression_errors(self):
         # Any MozRegressionError subclass is handled with a nice error message
-        self.runner.bisect_nightlies.side_effect = errors.MozRegressionError('my error')
+        self.runner.bisect_nightlies.side_effect = \
+            errors.MozRegressionError('my error')
         exitcode = self.do_cli([])
         self.assertIn('my error', exitcode)
 
     def test_handle_other_errors(self):
-        # other exceptions are just thrown as usual, so we have complete stacktrace
+        # other exceptions are just thrown as usual
+        # so we have complete stacktrace
         self.runner.bisect_nightlies.side_effect = NameError
         self.assertRaises(NameError, self.do_cli, [])
 
@@ -125,7 +130,9 @@ class TestMainCli(unittest.TestCase):
         self.assertIn('--find-fix flag', exitcode)
 
     def test_bisect_nightlies_with_find_fix_bad_usage(self):
-        exitcode = self.do_cli(['--good=2015-01-06', '--bad=2015-01-21', '--find-fix'])
+        exitcode = self.do_cli(['--good=2015-01-06',
+                                '--bad=2015-01-21',
+                                '--find-fix'])
         self.assertIn('not use the --find-fix flag', exitcode)
 
     def test_commad_make_use_of_commandtestrunner(self):
@@ -136,9 +143,12 @@ class TestMainCli(unittest.TestCase):
         releases = sorted(utils.releases().items(), key=lambda v: v[0])
         good = releases[0]
         bad = releases[-1]
-        self.do_cli(['--good-release=%s' % good[0], '--bad-release=%s' % bad[0]])
-        self.runner.bisect_nightlies.assert_called_with(utils.parse_date(good[1]),
-                                                        utils.parse_date(bad[1]))
+        self.do_cli(['--good-release=%s' % good[0],
+                     '--bad-release=%s' % bad[0]])
+
+        self.runner.bisect_nightlies.\
+            assert_called_with(utils.parse_date(good[1]),
+                               utils.parse_date(bad[1]))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -12,12 +12,14 @@ import os
 from mozregression.fetch_configs import create_config
 from mozregression import test_runner, errors
 
+
 class TestManualTestRunner(unittest.TestCase):
     def setUp(self):
         fetch_config = create_config('firefox', 'linux', 64)
         fetch_config.set_nightly_repo('my-repo')
         fetch_config.set_inbound_branch('my-branch')
-        self.runner = test_runner.ManualTestRunner(fetch_config, persist='/path/to')
+        self.runner = test_runner.ManualTestRunner(fetch_config,
+                                                   persist='/path/to')
 
     @patch('mozregression.test_runner.create_launcher')
     def test_nightly_create_launcher(self, create_launcher):
@@ -28,9 +30,11 @@ class TestManualTestRunner(unittest.TestCase):
             'build_date': datetime.date(2014, 12, 25),
             'build_url': 'http://my-url'
         })
-        create_launcher.assert_called_with('firefox', 'http://my-url',
-                                           persist_prefix='2014-12-25--my-repo--',
-                                           persist='/path/to')
+        create_launcher.\
+            assert_called_with('firefox', 'http://my-url',
+                               persist_prefix='2014-12-25--my-repo--',
+                               persist='/path/to')
+
         self.assertEqual(result_launcher, launcher)
 
     @patch('mozregression.test_runner.create_launcher')
@@ -75,7 +79,7 @@ class TestManualTestRunner(unittest.TestCase):
         get_verdict.return_value = 'g'
         launcher = Mock()
         create_launcher.return_value = launcher
-        build_infos = {'a':'b'}
+        build_infos = {'a': 'b'}
         result = self.runner.evaluate(build_infos)
 
         create_launcher.assert_called_with(build_infos)
@@ -86,13 +90,15 @@ class TestManualTestRunner(unittest.TestCase):
         self.assertEqual(result[0], 'g')
 
     def test_persist_none_is_overidden(self):
-        runner = test_runner.ManualTestRunner(self.runner.fetch_config, persist=None)
+        runner = test_runner.ManualTestRunner(self.runner.fetch_config,
+                                              persist=None)
         persist = runner.persist
         self.assertIsNotNone(persist)
         self.assertTrue(os.path.isdir(persist))
         # deleting the runner also delete the temp dir
         del runner
         self.assertFalse(os.path.exists(persist))
+
 
 class TestCommandTestRunner(unittest.TestCase):
     def setUp(self):
@@ -106,7 +112,8 @@ class TestCommandTestRunner(unittest.TestCase):
 
     @patch('mozregression.test_runner.CommandTestRunner.create_launcher')
     @patch('subprocess.call')
-    def evaluate(self, call, create_launcher, build_info={}, retcode=0, subprocess_call_effect=None):
+    def evaluate(self, call, create_launcher, build_info={},
+                 retcode=0, subprocess_call_effect=None):
         call.return_value = retcode
         if subprocess_call_effect:
             call.side_effect = subprocess_call_effect
@@ -119,11 +126,11 @@ class TestCommandTestRunner(unittest.TestCase):
         self.assertEqual('b', self.evaluate(retcode=1))
 
     def test_supbrocess_call(self):
-         self.evaluate()
-         command = self.subprocess_call.mock_calls[0][1][0]
-         kwargs = self.subprocess_call.mock_calls[0][2]
-         self.assertEqual(command, ['my', 'command'])
-         self.assertIn('env', kwargs)
+        self.evaluate()
+        command = self.subprocess_call.mock_calls[0][1][0]
+        kwargs = self.subprocess_call.mock_calls[0][2]
+        self.assertEqual(command, ['my', 'command'])
+        self.assertIn('env', kwargs)
 
     def test_env_vars(self):
         self.evaluate(build_info={'my': 'var', 'int': 15})
@@ -149,14 +156,20 @@ class TestCommandTestRunner(unittest.TestCase):
 
     def test_command_placeholder_error(self):
         self.runner.command = 'run {app_nam} "1"'
-        self.assertRaisesRegexp(errors.TestCommandError, 'formatting', self.evaluate)
+        self.assertRaisesRegexp(errors.TestCommandError,
+                                'formatting',
+                                self.evaluate)
 
     def test_command_empty_error(self):
-        # in case the command line is empty, subprocess.call will raise IndexError
-        self.assertRaisesRegexp(errors.TestCommandError, 'Empty', self.evaluate,
+        # in case the command line is empty,
+        # subprocess.call will raise IndexError
+        self.assertRaisesRegexp(errors.TestCommandError,
+                                'Empty', self.evaluate,
                                 subprocess_call_effect=IndexError)
 
     def test_command_missing_error(self):
-        # in case the command is missing or not executable, subprocess.call will raise IOError
-        self.assertRaisesRegexp(errors.TestCommandError, 'not found', self.evaluate,
+        # in case the command is missing or not executable,
+        # subprocess.call will raise IOError
+        self.assertRaisesRegexp(errors.TestCommandError,
+                                'not found', self.evaluate,
                                 subprocess_call_effect=OSError)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,6 +8,7 @@ import requests
 from cachecontrol import CacheControl
 from mozregression import utils, errors, limitedfilecache
 
+
 class TestUrlLinks(unittest.TestCase):
     @patch('requests.get')
     def test_url_no_links(self, get):
@@ -24,7 +25,7 @@ class TestUrlLinks(unittest.TestCase):
         """)
         self.assertEquals(utils.url_links(''),
                           ['thing/', 'thing2/'])
-    
+
     @patch('requests.get')
     def test_url_with_links_regex(self, get):
         get.return_value = Mock(text="""
@@ -37,6 +38,7 @@ class TestUrlLinks(unittest.TestCase):
             utils.url_links('', regex="thing2.*"),
             ['thing2/'])
 
+
 class TestParseDate(unittest.TestCase):
     def test_valid_date(self):
         date = utils.parse_date("2014-07-05")
@@ -45,6 +47,7 @@ class TestParseDate(unittest.TestCase):
     def test_invalid_date(self):
         self.assertRaises(errors.DateFormatError, utils.parse_date,
                           "invalid_format")
+
 
 class TestParseBits(unittest.TestCase):
     @patch('mozregression.utils.mozinfo')
@@ -58,6 +61,7 @@ class TestParseBits(unittest.TestCase):
         mozinfo.bits = 64
         self.assertEqual(utils.parse_bits('32'), 32)
         self.assertEqual(utils.parse_bits('64'), 64)
+
 
 class TestDownloadUrl(unittest.TestCase):
     def setUp(self):
@@ -98,21 +102,37 @@ class TestDownloadUrl(unittest.TestCase):
         self.assertRaises(Exception, utils.download_url, 'http://toto', fname)
         remove.assert_called_once_with(fname + '.part')
 
+
 class TestGetBuildUrl(unittest.TestCase):
     def test_for_linux(self):
-        self.assertEqual(utils.get_build_regex('test', 'linux', 32), r'test.*linux-i686\.tar.bz2')
-        self.assertEqual(utils.get_build_regex('test', 'linux', 64), r'test.*linux-x86_64\.tar.bz2')
-        self.assertEqual(utils.get_build_regex('test', 'linux', 64, with_ext=False), r'test.*linux-x86_64')
+        self.assertEqual(utils.get_build_regex('test', 'linux', 32),
+                         r'test.*linux-i686\.tar.bz2')
+
+        self.assertEqual(utils.get_build_regex('test', 'linux', 64),
+                         r'test.*linux-x86_64\.tar.bz2')
+
+        self.assertEqual(utils.get_build_regex('test', 'linux', 64,
+                                               with_ext=False),
+                         r'test.*linux-x86_64')
 
     def test_for_win(self):
-        self.assertEqual(utils.get_build_regex('test', 'win', 32), r'test.*win32\.zip')
-        self.assertEqual(utils.get_build_regex('test', 'win', 64), r'test.*win64-x86_64\.zip')
-        self.assertEqual(utils.get_build_regex('test', 'win', 64, with_ext=False), r'test.*win64-x86_64')
+        self.assertEqual(utils.get_build_regex('test', 'win', 32),
+                         r'test.*win32\.zip')
+        self.assertEqual(utils.get_build_regex('test', 'win', 64),
+                         r'test.*win64-x86_64\.zip')
+        self.assertEqual(utils.get_build_regex('test', 'win', 64,
+                                               with_ext=False),
+                         r'test.*win64-x86_64')
 
     def test_for_mac(self):
-        self.assertEqual(utils.get_build_regex('test', 'mac', 32), r'test.*mac.*\.dmg')
-        self.assertEqual(utils.get_build_regex('test', 'mac', 64), r'test.*mac.*\.dmg')
-        self.assertEqual(utils.get_build_regex('test', 'mac', 64, with_ext=False), r'test.*mac.*')
+        self.assertEqual(utils.get_build_regex('test', 'mac', 32),
+                         r'test.*mac.*\.dmg')
+        self.assertEqual(utils.get_build_regex('test', 'mac', 64),
+                         r'test.*mac.*\.dmg')
+        self.assertEqual(utils.get_build_regex('test', 'mac', 64,
+                                               with_ext=False),
+                         r'test.*mac.*')
+
 
 class TestRelease(unittest.TestCase):
     def test_valid_release_to_date(self):
@@ -134,7 +154,8 @@ class TestRelease(unittest.TestCase):
             fields = line.translate(None, " ").split(":")
             version = int(fields[0])
             date = fields[1]
-            self.assertTrue(firefox_releases.has_key(version))
+
+            self.assertTrue(version in firefox_releases)
             self.assertEquals(date, firefox_releases[version])
 
     def test_invalid_release_to_date(self):
@@ -171,7 +192,8 @@ class TestHTTPCache(unittest.TestCase):
         # so it makes verifying that we're actually using it
         # a little messy
         for k, v in a_session.adapters.items():
-            self.assertTrue(isinstance(v.cache, limitedfilecache.LimitedFileCache))
+            self.assertTrue(isinstance(v.cache,
+                            limitedfilecache.LimitedFileCache))
 
     def test_set_http_session_with_get_defaults(self):
         original_get = Mock()


### PR DESCRIPTION
Hi guys,
(This is my first bug)

Just finished working on the [pep8 check for travis ci build on mozregression](https://bugzilla.mozilla.org/show_bug.cgi?id=1127575) feature. While making the code PEP-8 compliant I was not exactly focussing on the neatest solution, but more the quickest one, If considered a good idea I will open an issue about neatening up the whole project (if there is not already one).