### PR TITLE
Bug 1111310 - Allow to configure mozregression with config file(s)

### DIFF
--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -12,7 +12,10 @@ import mozinfo
 import datetime
 import sys
 import atexit
+import os
+
 from argparse import ArgumentParser
+from ConfigParser import SafeConfigParser, Error
 from mozlog.structured import commandline, get_default_logger
 from requests.exceptions import RequestException
 
@@ -27,6 +30,28 @@ from mozregression.bisector import BisectRunner
 from mozregression.launchers import REGISTRY as APP_REGISTRY
 from mozregression.test_runner import ManualTestRunner, CommandTestRunner
 
+DEFAULT_CONF_FNAME = os.path.expanduser(os.path.join("~",
+                                                     ".mozregression.cfg"))
+
+
+def get_defaults(conf_name):
+    """
+    Get custom defaults from configuration file in argument
+    """
+    defaults = {}
+
+    if os.path.isfile(conf_name):
+        try:
+            config = SafeConfigParser()
+            config.read([conf_name])
+            defaults = dict(config.items("Defaults"))
+            print("%s loaded" % conf_name)
+        except Error as err:
+            sys.exit("Error while parsing %s =>  no custom default values\n%s"
+                     % (conf_name, str(err)))
+
+    return defaults
+
 
 def parse_args(argv=None):
     """
@@ -40,6 +65,7 @@ def parse_args(argv=None):
              " %(prog)s [OPTIONS]"
              " --inbound --bad-rev BAD_REV --good-rev GOOD_REV")
 
+    defaults = get_defaults(DEFAULT_CONF_FNAME)
     parser = ArgumentParser(usage=usage)
     parser.add_argument("--version", action="version", version=__version__,
                         help=("print the mozregression version number and"
@@ -94,6 +120,7 @@ def parse_args(argv=None):
                         help="addon to install; repeat for multiple addons.")
 
     parser.add_argument("-p", "--profile",
+                        default=defaults.get("profile"),
                         metavar="PATH",
                         help="profile to use with nightlies.")
 
@@ -107,20 +134,22 @@ def parse_args(argv=None):
 
     parser.add_argument("-n", "--app",
                         choices=FC_REGISTRY.names(),
-                        default="firefox",
+                        default=defaults.get("app", "firefox"),
                         help="application name. Default: %(default)s.")
 
     parser.add_argument("--repo",
                         metavar="[mozilla-aurora|mozilla-beta|...]",
+                        default=defaults.get("repo"),
                         help="repository name used for nightly hunting.")
 
     parser.add_argument("--inbound-branch",
                         metavar="[b2g-inbound|fx-team|...]",
+                        default=defaults.get("inbound-branch"),
                         help="inbound branch name on ftp.mozilla.org.")
 
     parser.add_argument("--bits",
                         choices=("32", "64"),
-                        default=mozinfo.bits,
+                        default=defaults.get("bits", mozinfo.bits),
                         help=("force 32 or 64 bit version (only applies to"
                               " x86_64 boxes). Default: %(default)s bits."))
 
@@ -131,14 +160,18 @@ def parse_args(argv=None):
                               " as bad."))
 
     parser.add_argument("--persist",
+                        default=defaults.get("persist"),
                         help=("the directory in which downloaded files are"
                               " to persist."))
 
     parser.add_argument("--http-cache-dir",
+                        default=defaults.get("http-cache-dir"),
                         help=("the directory for caching http requests."
                               " If not set there will be an in-memory cache"
                               " used."))
-    parser.add_argument('--http-timeout', type=float, default=30.0,
+
+    parser.add_argument('--http-timeout', type=float,
+                        default=float(defaults.get("http-timeout", 30.0)),
                         help=("Timeout in seconds to abort requests when there"
                               " is no activity from the server. Default to"
                               " %(default)s seconds - increase this if you"

--- a/tests/unit/test_bisector.py
+++ b/tests/unit/test_bisector.py
@@ -378,12 +378,14 @@ class TestBisector(unittest.TestCase):
 
 
 class TestBisectRunner(unittest.TestCase):
+    @patch('mozregression.main.get_defaults')
     @patch('mozregression.bisector.get_default_logger')
-    def setUp(self, get_default_logger):
+    def setUp(self, get_default_logger, get_defaults):
         self.fetch_config = Mock()
         self.test_runner = Mock()
         self.logger = Mock()
         self.logs = []
+        get_defaults.return_value = dict()
         get_default_logger.return_value = Mock(info=self.logs.append)
         self.brunner = BisectRunner(self.fetch_config,
                                     self.test_runner,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,6 +7,8 @@
 import unittest
 from mock import patch, Mock
 import datetime
+import tempfile
+import os
 
 from mozregression import main, utils, errors
 from mozregression.test_runner import CommandTestRunner
@@ -44,6 +46,40 @@ class TestMainCli(unittest.TestCase):
         output = ''.join(output)
         self.assertEqual(exitcode, 0)
         self.assertIn('usage:', output)
+
+    def test_get_erronous_cfg_defaults(self):
+        handle, filepath = tempfile.mkstemp()
+        self.addCleanup(os.unlink, filepath)
+
+        with os.fdopen(handle, 'w') as conf_file:
+            conf_file.write('aaaaaaaaaaa [Defaults]\n')
+
+        with self.assertRaises(SystemExit):
+            main.get_defaults(filepath)
+
+    def test_get_defaults(self):
+        valid_values = {'http-timeout': '10.2',
+                        'http-cache-dir': '/home/foo/.mozregression',
+                        'bits': '64'}
+
+        handle, filepath = tempfile.mkstemp()
+        conf_default =  main.DEFAULT_CONF_FNAME
+
+        self.addCleanup(os.unlink, filepath)
+        self.addCleanup(setattr, main, "DEFAULT_CONF_FNAME", conf_default)
+
+        main.DEFAULT_CONF_FNAME = filepath
+
+        with os.fdopen(handle, 'w') as conf_file:
+            conf_file.write('[Defaults]\n')
+            for key, value in valid_values.iteritems():
+                conf_file.write("%s=%s\n" % (key, value))
+
+        options = main.parse_args(['--bits=32'])
+
+        self.assertEqual(options.http_timeout, 10.2)
+        self.assertEqual(options.http_cache_dir, '/home/foo/.mozregression')
+        self.assertEqual(options.bits, 32)
 
     def test_without_args(self):
         self.runner.bisect_nightlies.return_value = 0

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -18,12 +18,14 @@ class TestMainCli(unittest.TestCase):
     def setUp(self):
         self.runner = Mock()
 
+    @patch('mozregression.main.get_defaults')
     @patch('mozlog.structured.commandline.setup_logging')
     @patch('mozregression.main.set_http_cache_session')
     @patch('mozregression.limitedfilecache.get_cache')
     @patch('mozregression.main.ResumeInfoBisectRunner')
     def do_cli(self, argv, BisectRunner, get_cache, set_http_cache_session,
-               setup_logging):
+               setup_logging, get_defaults):
+        get_defaults.return_value = dict()
         def create_runner(fetch_config, test_runner, options):
             self.runner.fetch_config = fetch_config
             self.runner.test_runner = test_runner


### PR DESCRIPTION
mozregression try to load a configuration file located on
"~/mozregression.cfg" and takes its values as default values
(overridable by command line passed args).