### PR TITLE
#Bug 1106804 - --inbound-branch should imply --inbound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/*
 *.pyc
 *.swp
 .DS_Store
+build/*
+coveragerc

--- a/mozregression/bisector.py
+++ b/mozregression/bisector.py
@@ -420,7 +420,7 @@ class BisectRunner(object):
         if isinstance(handler, NightlyHandler):
             info = '--good=%s --bad=%s' % (handler.good_date, handler.bad_date)
         else:
-            info = ('--inbound --good-rev=%s --bad-rev=%s'
+            info = ('--good-rev=%s --bad-rev=%s'
                     % (handler.good_revision, handler.bad_revision))
         options = self.options
         info += ' --app=%s' % options.app

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -37,7 +37,7 @@ def parse_args(argv=None):
              " [[--good GOOD_DATE]|[--good-release GOOD_RELEASE]]"
              "\n"
              " %(prog)s [OPTIONS]"
-             " --inbound --bad-rev BAD_REV --good-rev GOOD_REV")
+             " --bad-rev BAD_REV --good-rev GOOD_REV")
 
     parser = ArgumentParser(usage=usage)
     parser.add_argument("--version", action="version", version=__version__,
@@ -69,18 +69,13 @@ def parse_args(argv=None):
                         help=("last known good nightly build. This option is"
                               " incompatible with --good."))
 
-    parser.add_argument("--inbound",
-                        action="store_true",
-                        help=("use inbound instead of nightlies (use"
-                              " --good-rev and --bad-rev options."))
-
     parser.add_argument("--bad-rev", dest="first_bad_revision",
-                        help=("first known bad revision (use with"
-                              " --inbound)."))
+                        help=("first known bad revision (for inbound"
+                              " bisection)."))
 
     parser.add_argument("--good-rev", dest="last_good_revision",
-                        help=("last known good revision (use with"
-                              " --inbound)."))
+                        help=("last known good revision (for inbound"
+                              " bisection)."))
 
     parser.add_argument("--find-fix", action="store_true",
                         help="Search for a bug fix instead of a regression.")
@@ -247,10 +242,12 @@ def cli(argv=None):
         # can go to inbound from nightly.
         fetch_config.set_inbound_branch(options.inbound_branch)
 
-    if options.inbound:
+    # bisect inbound if last good revision or first bad revision are set
+    if options.first_bad_revision or options.last_good_revision:
         bisect = bisect_inbound
     else:
         bisect = bisect_nightlies
+
     try:
         launcher_class = APP_REGISTRY.get(fetch_config.app_name)
         launcher_class.check_is_runnable()

--- a/tests/unit/test_bisector.py
+++ b/tests/unit/test_bisector.py
@@ -412,7 +412,6 @@ class TestBisectRunner(unittest.TestCase):
         self.assertIn('--bits=64', result)
         self.assertIn('--good=2015-01-01', result)
         self.assertIn('--bad=2015-01-11', result)
-        self.assertNotIn('--inbound', result)
 
         self.assertNotIn('--find-fix', result)
         result = self.print_resume_info(NightlyHandler, find_fix=True)
@@ -448,7 +447,6 @@ class TestBisectRunner(unittest.TestCase):
         self.assertIn('--app=b2g', result)
         self.assertIn('--good-rev=123', result)
         self.assertIn('--bad-rev=456', result)
-        self.assertIn('--inbound', result)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -60,7 +60,7 @@ class TestMainCli(unittest.TestCase):
 
     def test_basic_inbound(self):
         self.runner.bisect_inbound.return_value = 0
-        exitcode = self.do_cli(['--inbound', '--good-rev=1', '--bad-rev=5'])
+        exitcode = self.do_cli(['--good-rev=1', '--bad-rev=5'])
         # application is by default firefox
         self.assertEqual(self.runner.fetch_config.app_name, 'firefox')
         # bisect_inbound has been called
@@ -70,9 +70,7 @@ class TestMainCli(unittest.TestCase):
 
     def test_inbound_revs_must_be_given(self):
         argslist = [
-            ['--inbound'],
-            ['--inbound', '--good-rev=1'],
-            ['--inbound', '--bad-rev=5'],
+            ['--good-rev=1'], ['--bad-rev=5'],
         ]
         for args in argslist:
             exitcode = self.do_cli(args)
@@ -81,7 +79,7 @@ class TestMainCli(unittest.TestCase):
     @patch('mozregression.fetch_configs.FirefoxConfig.is_inbound')
     def test_inbound_must_be_doable(self, is_inbound):
         is_inbound.return_value = False
-        exitcode = self.do_cli(['--inbound', '--good-rev=1', '--bad-rev=5'])
+        exitcode = self.do_cli(['--good-rev=1', '--bad-rev=5'])
         self.assertIn('Unable to bissect inbound', exitcode)
 
     @patch('mozregression.main.formatted_valid_release_dates')


### PR DESCRIPTION
As suggested by @wlach We want to bisect inbound if last good revision and first bad revision are set, so I added a condition for this. Let me know if this is the correct way to implement it.