### PR TITLE
Bug/1159728 [gui] limit the choices for the bits fields

### DIFF
--- a/gui/mozregui/wizard.py
+++ b/gui/mozregui/wizard.py
@@ -89,6 +89,13 @@ class IntroPage(WizardPage):
         if old_bisect_index == 1 and len(bisect_types) == 2:
             bisect_index = 1
         self.ui.bisect_combo.setCurrentIndex(bisect_index)
+        available_bits = self.fetch_config.available_bits()
+        if not available_bits:
+            self.ui.bits_combo.hide()
+            self.ui.label_4.hide()
+        else:
+            self.ui.bits_combo.show()
+            self.ui.label_4.show()
 
     def validatePage(self):
         app_name = self.fetch_config.app_name

--- a/gui/mozregui/wizard.py
+++ b/gui/mozregui/wizard.py
@@ -61,12 +61,13 @@ class IntroPage(WizardPage):
         self.ui.app_combo.setModel(self.app_model)
         self.bisect_model = QStringListModel()
         self.ui.bisect_combo.setModel(self.bisect_model)
-        self.bits_model = QStringListModel(['32', '64'])
-        self.ui.bits_combo.setModel(self.bits_model)
         if mozinfo.bits == 64:
+            self.bits_model = QStringListModel(['32', '64'])
             bits_index = 1
         elif mozinfo.bits == 32:
+            self.bits_model = QStringListModel(['32'])
             bits_index = 0
+        self.ui.bits_combo.setModel(self.bits_model)
         self.ui.bits_combo.setCurrentIndex(bits_index)
 
         self.ui.app_combo.currentIndexChanged.connect(self._set_fetch_config)

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -48,6 +48,13 @@ class CommonConfig(object):
         """
         return isinstance(self, InboundConfigMixin)
 
+    def available_bits(self):
+        """
+        Returns the no. of bits of the OS for which the application should
+        run.
+        """
+        return (32, 64)
+
 
 class NightlyConfigMixin(object):
     """
@@ -254,6 +261,9 @@ class FennecConfig(CommonConfig,
 
     def build_info_regex(self):
         return r'fennec-.*\.txt'
+
+    def available_bits(self):
+        return ()
 
 
 @REGISTRY.register('fennec-2.3', attr_value='fennec')


### PR DESCRIPTION
Added the following changes:
1) Only 32-bits is presented to the user in the drop down menu
    if the user uses a 32 bit OS (as a 32 bit OS can't run a 64-
    bit application), otherwise both the options are shown.
2) Hiding the bits field when the application is 'fennec' or
    fennec-2.3'. The fennec application can only run on a
    connected android device- so we don't care about the bits here.