### PR TITLE
Fix bug 1165434, use a global temp dir when no persists defined

### DIFF
--- a/gui/mozregui/bisection.py
+++ b/gui/mozregui/bisection.py
@@ -222,8 +222,12 @@ class BisectRunner(QObject):
         # apply the global prefs now
         apply_prefs(global_prefs)
 
+        persist = global_prefs['persist']
+        if not persist:
+            persist = self.mainwindow.persist
+
         self.bisector = GuiBisector(fetch_config,
-                                    persist=global_prefs['persist'])
+                                    persist=persist)
         # create a QThread, and move self.bisector in it. This will
         # allow to the self.bisector slots (connected after the move)
         # to be automatically called in the thread.

--- a/gui/mozregui/main.py
+++ b/gui/mozregui/main.py
@@ -2,6 +2,8 @@
 import sys
 import mozregression
 import mozregui
+import mozfile
+from tempfile import mkdtemp
 from PyQt4.QtGui import QApplication, QMainWindow, QMessageBox
 from PyQt4.QtCore import pyqtSlot as Slot, QSettings
 
@@ -50,7 +52,13 @@ class MainWindow(QMainWindow):
         self.bisect_runner.running_state_changed.connect(
             self.ui.actionStop_the_bisection.setEnabled)
 
+        self.persist = mkdtemp()
+
         self.read_settings()
+
+    @Slot()
+    def clear(self):
+        mozfile.remove(self.persist)
 
     def read_settings(self):
         settings = QSettings()
@@ -100,6 +108,7 @@ if __name__ == '__main__':
     # Create the main window and show it
     win = MainWindow()
     app.aboutToQuit.connect(win.bisect_runner.stop)
+    app.aboutToQuit.connect(win.clear)
     win.show()
     win.start_bisection_wizard()
     # Enter Qt application main loop


### PR DESCRIPTION
When quitting mozgui after an app downloading for a bisection, when
persist is not defined by the user, the temp dir persists.
To fix this behaviour, we now create a temp_dir specific for the
mainwindow and pass it to the Bisector class.
Then on close, we explicly delete it.