### PR TITLE
use the filecache extra dependency with cachecontrol

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,7 @@ setup(name="mozregression",
           'mozversion >= 1.2',
           'requests >= 2.5.0',
           'redo',
-          'cachecontrol >= 0.10.2',
-          # used in conjunction with cachecontrol
-          'lockfile >= 0.10.2',
+          'cachecontrol[filecache] >= 0.11.5',
           'futures >= 2.1.6',
           'mozdevice >= 0.43'
       ],


### PR DESCRIPTION
I've made a patch for cachecontrol to easily track dependencies when using the local file cache (as we do):

https://github.com/ionrock/cachecontrol/commit/57dddb23ff220e4bac2df5ad5ff5df8304098ff5

This has now been released, so we should use it (this is called extra dependencies for pip).

@wlach @jpigree  r?