### PR TITLE
Override default selection theme to keep cells verdict color

### DIFF
--- a/gui/mozregui/report_delegate.py
+++ b/gui/mozregui/report_delegate.py
@@ -8,7 +8,12 @@ class ReportItemDelegate(QStyledItemDelegate):
         QStyledItemDelegate.__init__(self, parent, *args)
 
     def paint(self, painter, option, index):
-        # Write status
+        # if item selected, override default theme
+        # Keeps verdict color for cells and use a bold font
+        if option.state & QStyle.State_Selected:
+            option.state &= ~ QStyle.State_Selected
+            option.font.setBold(True)
+
         QStyledItemDelegate.paint(self, painter, option, index)
 
         item = index.model().get_item(index)


### PR DESCRIPTION
Cells Background color represents the verdict on the nightly by the user
of mozregui. But the selection default theme replace it with a blue background.
 
It hides a very useful information for the user.

The fix overrides this behavior and keeps verdict color on selected cells
but bolden its text.