### PR TITLE
Bug 1173981 - [gui] add colors for the log levels

### DIFF
--- a/gui/mozregui/log_report.py
+++ b/gui/mozregui/log_report.py
@@ -1,6 +1,15 @@
 from PyQt4.QtCore import QObject, pyqtSlot as Slot, pyqtSignal as Signal
-from PyQt4.QtGui import QPlainTextEdit, QTextCursor
+from PyQt4.QtGui import QPlainTextEdit, QTextCursor, QColor, \
+    QTextCharFormat
 from datetime import datetime
+
+COLORS = {
+    'DEBUG': QColor(6, 146, 6),         # green
+    'INFO': QColor(250, 184, 4),        # deep yellow
+    'WARNING': QColor(255, 0, 0, 127),  # red
+    'CRITICAL': QColor(255, 0, 0, 127),
+    'ERROR': QColor(255, 0, 0, 127),
+    }
 
 
 class LogView(QPlainTextEdit):
@@ -9,7 +18,18 @@ class LogView(QPlainTextEdit):
         time_info = datetime.fromtimestamp((data['time']/1000)).isoformat()
         log_message = '%s: %s : %s' % (
             time_info, data['level'], data['message'])
-        self.appendPlainText(log_message)
+        message_document = self.document()
+        cursor_to_add = QTextCursor(message_document)
+        cursor_to_add.movePosition(cursor_to_add.End)
+        cursor_to_add.insertText(log_message + '\n')
+        if data['level'] in COLORS:
+            fmt = QTextCharFormat()
+            fmt.setForeground(COLORS[data['level']])
+            cursor_to_add.movePosition(cursor_to_add.PreviousBlock)
+            cursor_to_add_fmt = message_document.find(data['level'],
+                                                      cursor_to_add.position())
+            cursor_to_add_fmt.mergeCharFormat(fmt)
+        self.ensureCursorVisible()
         counter = self.blockCount()
 
         # do not display more than 1000 log lines


### PR DESCRIPTION
Now, thing is like this.

We got two kinds of methods to make our level message more obvious. And we do need to choose one from them to make log view more friendly. So I will paste them blow and please give me some feedback before I finish this patch.
![screenshot from 2015-06-30 19 22 04](https://cloud.githubusercontent.com/assets/2166227/8430330/18fd097c-1f63-11e5-8d98-4505e8ad275a.png)

![screenshot from 2015-06-30 19 34 02](https://cloud.githubusercontent.com/assets/2166227/8430343/2472071c-1f63-11e5-9679-2f0012669ac9.png)

@jpigree @parkouss please tell me which one you prefer, or you have a better ideal about the color of level message. Thank you very much! :)
