### PR TITLE
add the ability to keep downloading files in background

### DIFF
--- a/mozregression/download_manager.py
+++ b/mozregression/download_manager.py
@@ -269,10 +269,13 @@ class BuildDownloadManager(DownloadManager):
     """
     A DownloadManager specialized to download builds.
     """
-    def __init__(self, logger, destdir, session=requests):
+    def __init__(self, logger, destdir, session=requests,
+                 background_dl_policy='cancel'):
         DownloadManager.__init__(self, destdir, session=session)
         self.logger = logger
         self._downloads_bg = set()
+        assert background_dl_policy in ('cancel', 'keep')
+        self.background_dl_policy = background_dl_policy
 
     def _extract_download_info(self, build_info):
         if build_info['build_type'] == 'nightly':
@@ -318,7 +321,8 @@ class BuildDownloadManager(DownloadManager):
         dest = self.get_dest(fname)
         # first, stop all downloads in background (except the one for this
         # build if any)
-        self.cancel(cancel_if=lambda dl: dest != dl.get_dest())
+        if self.background_dl_policy == 'cancel':
+            self.cancel(cancel_if=lambda dl: dest != dl.get_dest())
 
         dl = self.download(build_url, fname)
         if dl:

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -190,6 +190,14 @@ def parse_args(argv=None):
                         help=("Do not download next builds in the background"
                               " while evaluating the current build."))
 
+    parser.add_argument('--background-dl-policy', choices=('cancel', 'keep'),
+                        default=defaults.get('background-dl-policy', 'cancel'),
+                        help=('Policy to use for background downloads.'
+                              ' Possible values are "cancel" to cancel all'
+                              ' pending background downloads or "keep" to keep'
+                              ' downloading them when persist mode is enabled.'
+                              ' The default is %(default)s.'))
+
     commandline.add_logging_group(
         parser,
         include_formatters=commandline.TEXT_FORMATTERS

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -318,7 +318,7 @@ class TestBuildDownloadManager(unittest.TestCase):
 
     @patch("mozregression.download_manager.BuildDownloadManager."
            "_extract_download_info")
-    def test_focus_download(self, extract):
+    def _test_focus_download(self, other_canceled, extract):
         extract.return_value = ('http://foo/bar', 'myfile')
         current_dest = os.path.join('dest', 'myfile')
         other_dest = os.path.join('dest', 'otherfile')
@@ -343,12 +343,19 @@ class TestBuildDownloadManager(unittest.TestCase):
         self.assertFalse(curent_download.is_canceled())
         curent_download.wait.assert_called_with()
 
-        self.assertTrue(other_download.is_canceled())
+        self.assertEquals(other_download.is_canceled(), other_canceled)
 
         self.dl_manager.logger.info.assert_called_with(
             "Downloading build from: http://foo/bar")
 
         self.assertEquals(result, current_dest)
+
+    def test_focus_download(self):
+        self._test_focus_download(True)
+
+    def test_focus_download_with_keep_policy(self):
+        self.dl_manager.background_dl_policy = "keep"
+        self._test_focus_download(False)
 
     @patch("mozregression.download_manager.BuildDownloadManager."
            "_extract_download_info")


### PR DESCRIPTION
This add a new command line option '--background-dl-policy' that can be filled
with two values:
 - 'cancel' (the default) cancel any background build as soon as we know
   which build the user need
 - 'keep' this do not stop background downloads, so every file downloaded
   (even non tested) is kept in the persist folder if any.