### PR TITLE
Taskcluster gui bundle

### DIFF
--- a/gui/build.py
+++ b/gui/build.py
@@ -101,6 +101,12 @@ def call_cx_freeze():
             paths.insert(0, p)
     args.append('--include-path=%s' % os.pathsep.join(['.', '..'] + paths))
 
+    # find taskcluster apis.json file
+    import taskcluster.client
+    apis_json = os.path.join(os.path.dirname(taskcluster.client.__file__),
+                             'apis.json')
+    args.append("--zip-include=%s=taskcluster/apis.json" % apis_json)
+
     args.append('--target-dir=dist')
     args.append('mozregui/main.py')
     call(*args)

--- a/gui/build.py
+++ b/gui/build.py
@@ -111,6 +111,10 @@ def call_cx_freeze():
     args.append('mozregui/main.py')
     call(*args)
 
+    # copy the required cacert.pem file for requests library
+    import requests.certs
+    shutil.copy(requests.certs.where(), "dist/cacert.pem")
+
 
 def do_bundle(options):
     do_uic(options, True)

--- a/gui/mozregui/global_prefs.py
+++ b/gui/mozregui/global_prefs.py
@@ -2,6 +2,7 @@ from PyQt4.QtCore import QSettings, QVariant
 from PyQt4.QtGui import QDialog
 
 from mozregui.ui.global_prefs import Ui_GlobalPrefs
+from mozregui import patch_requests
 
 from mozregression import limitedfilecache
 from mozregression.utils import set_http_cache_session
@@ -39,7 +40,9 @@ def apply_prefs(options):
     cache_session = limitedfilecache.get_cache(options['http_cache_dir'],
                                                limitedfilecache.ONE_GIGABYTE)
     set_http_cache_session(cache_session,
-                           get_defaults={"timeout": options['http_timeout']})
+                           get_defaults={"timeout": options['http_timeout'],
+                                         "verify": patch_requests.cacert_path()
+                                         })
     # persist options have to be passed in the bisection, not handled here.
 
 

--- a/gui/mozregui/main.py
+++ b/gui/mozregui/main.py
@@ -1,3 +1,7 @@
+# first thing, patch requests lib if required
+from mozregui import patch_requests
+patch_requests.patch()
+
 # Import PyQt4 classes
 import sys
 import mozregression

--- a/gui/mozregui/patch_requests.py
+++ b/gui/mozregui/patch_requests.py
@@ -1,0 +1,25 @@
+import sys
+import os
+
+# only True when running from frozen (bundled) app
+IS_FROZEN = getattr(sys, 'frozen', False)
+
+
+def cacert_path():
+    """return the path to cacert.pem (or None if not required)"""
+    if IS_FROZEN:
+        return os.path.join(os.path.dirname(sys.executable), "cacert.pem")
+
+
+def patch():
+    # patch requests.request so taskcluster can use the right cacert.pem file.
+    if IS_FROZEN:
+        import requests
+        pem = cacert_path()
+        old_request = requests.request
+
+        def _patched_request(*args, **kwargs):
+            kwargs['verify'] = pem
+            return old_request(*args, **kwargs)
+
+        requests.request = _patched_request


### PR DESCRIPTION
This fixes the bundled (ie frozen) version of mozregression gui.

Two fixes:
- include a taskcluster package required file that was not bundled
- requests requires a cacert.pem file that taskcluster (and mozregression also) now uses.