### PR TITLE
raise MozregressionError if os is unknown or unsupported

### DIFF
--- a/mozregression/utils.py
+++ b/mozregression/utils.py
@@ -166,6 +166,11 @@ def get_build_regex(name, os, bits, with_ext=True):
             suffix, ext = r".*linux-i686", r"\.tar.bz2"
     elif os == "mac":
         suffix, ext = r".*mac.*", r"\.dmg"
+    else:
+        raise errors.MozRegressionError(
+            "mozregression supports linux, mac and windows but your"
+            " os is reported as '%s'." % os
+        )
 
     regex = '%s%s' % (name, suffix)
     if with_ext:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -89,6 +89,10 @@ class TestGetBuildUrl(unittest.TestCase):
                                                with_ext=False),
                          r'test.*mac.*')
 
+    def test_unknown_os(self):
+        with self.assertRaises(errors.MozRegressionError):
+            utils.get_build_regex('test', 'unknown', 32)
+
 
 class TestRelease(unittest.TestCase):
     def test_valid_release_to_date(self):


### PR DESCRIPTION
This allow to exit cleanly with a nice error message instead
of a full stack trace that is hard to understand.