### PR TITLE
Clone existing mozprofiles to prevent persistence

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -80,8 +80,12 @@ class Launcher(object):
 
     def _create_profile(self, profile=None, addons=(), preferences=None):
         if profile:
-            profile = self.profile_class(profile=profile, addons=addons,
-                                         preferences=preferences)
+            # mozprofile makes some changes in the profile that can not
+            # be undone. Let's clone the profile to not have side effect
+            # on existing profile.
+            # see https://bugzilla.mozilla.org/show_bug.cgi?id=999009
+            profile = self.profile_class.clone(profile, addons=addons,
+                                               preferences=preferences)
         elif len(addons):
             profile = self.profile_class(addons=addons,
                                          preferences=preferences)


### PR DESCRIPTION
* When using an existing mozprofile, mozregression modifies it without
reverting the changes after the tests. This fix makes it clone the
existing profile in order to preserve its state.

* This fix needs mozprofile >= 0.24 in order to clean up the profile
created into the tmp directory when no reference to the object is left.

=> Fortunately, setup.py is already updated to 0.25 so no change needed.

* Adapted launcher unit tests accordingly.

* Factorized multiple hard coded strings into launcher test cases.