### PR TITLE
Bug 1192485 - handle errors when running the tested application

### DIFF
--- a/mozregression/errors.py
+++ b/mozregression/errors.py
@@ -68,3 +68,9 @@ class UnavailableRelease(MozRegressionError):
         MozRegressionError.__init__(self,
                                     "Unable to find a matching date for"
                                     " release %s" % release)
+
+
+class LauncherError(MozRegressionError):
+    """
+    Error when running the tested application.
+    """

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -19,7 +19,7 @@ import mozinstall
 import tempfile
 
 from mozregression.utils import ClassRegistry
-from mozregression.errors import LauncherNotRunnable
+from mozregression.errors import LauncherNotRunnable, LauncherError
 
 
 class Launcher(object):
@@ -42,14 +42,24 @@ class Launcher(object):
         self._running = False
         self._logger = get_default_logger('Test Runner')
 
-        self._install(dest)
+        try:
+            self._install(dest)
+        except Exception:
+            msg = "Unable to install %r" % dest
+            self._logger.error(msg, exc_info=True)
+            raise LauncherError(msg)
 
     def start(self, **kwargs):
         """
         Start the application.
         """
         if not self._running:
-            self._start(**kwargs)
+            try:
+                self._start(**kwargs)
+            except Exception:
+                msg = "Unable to start the application"
+                self._logger.error(msg, exc_info=True)
+                raise LauncherError(msg)
             self._running = True
 
     def stop(self):
@@ -57,7 +67,12 @@ class Launcher(object):
         Stop the application.
         """
         if self._running:
-            self._stop()
+            try:
+                self._stop()
+            except Exception:
+                msg = "Unable to stop the application"
+                self._logger.error(msg, exc_info=True)
+                raise LauncherError(msg)
             self._running = False
 
     def get_app_info(self):

--- a/mozregression/test_runner.py
+++ b/mozregression/test_runner.py
@@ -15,7 +15,7 @@ import shlex
 import os
 
 from mozregression.launchers import create_launcher
-from mozregression.errors import TestCommandError
+from mozregression.errors import TestCommandError, LauncherError
 
 
 class TestRunner(object):
@@ -111,7 +111,13 @@ class ManualTestRunner(TestRunner):
         launcher.start(**self.launcher_kwargs)
         app_infos = launcher.get_app_info()
         verdict = self.get_verdict(build_info, allow_back)
-        launcher.stop()
+        try:
+            launcher.stop()
+        except LauncherError:
+            # we got an error on process termination, but user
+            # already gave the verdict, so pass this "silently"
+            # (it would be logged from the launcher anyway)
+            pass
         return verdict, app_infos
 
 

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -88,6 +88,20 @@ class TestManualTestRunner(unittest.TestCase):
         launcher.stop.assert_called_with()
         self.assertEqual(result[0], 'g')
 
+    @patch('mozregression.test_runner.ManualTestRunner.create_launcher')
+    @patch('mozregression.test_runner.ManualTestRunner.get_verdict')
+    def test_evaluate_with_launcher_error_on_stop(self, get_verdict,
+                                                  create_launcher):
+        get_verdict.return_value = 'g'
+        launcher = Mock(stop=Mock(side_effect=errors.LauncherError))
+        create_launcher.return_value = launcher
+        build_infos = {'a': 'b'}
+        result = self.runner.evaluate(build_infos)
+
+        # the LauncherError is silently ignore here
+        launcher.stop.assert_called_with()
+        self.assertEqual(result[0], 'g')
+
 
 class TestCommandTestRunner(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This handle cases when we got some exception while:

 1. trying to install the application
 2. trying to start the application
 3. trying to stop the application.

For cases 1 and 2, this is an "uncoverable" error. So the raw
exception is printed, and we force skipping the build.

Case 3 can be recovered, so the only thing we do is print the raw
error, but we keep the verdict that the user entered and the
app_info dict extracted from the installed application.