### PR TITLE
Bug 1196188 - [gui] add tests for the addons editor

### DIFF
--- a/gui/tests/test_addons_editor.py
+++ b/gui/tests/test_addons_editor.py
@@ -1,0 +1,64 @@
+import pytest
+import tempfile
+import mozfile
+
+from PyQt4.QtCore import Qt, QStringList
+from mock import patch
+from mozregui.addons_editor import AddonsWidgetEditor
+
+
+@pytest.fixture
+def addons_editor(qtbot):
+    widget = AddonsWidgetEditor()
+    qtbot.addWidget(widget)
+    widget.show()
+    qtbot.waitForWindowShown(widget)
+    return widget
+
+
+def get_view_focus(addons_editor):
+    return addons_editor.ui.list_view.viewport().focusWidget
+
+
+def test_create_addons_editor(addons_editor):
+    assert addons_editor.get_addons() == []
+
+
+@pytest.fixture
+def addons_file(request):
+    # create a temp addons file
+    f = tempfile.NamedTemporaryFile(suffix='.xpi', dir='.', delete=False)
+    f.close()
+    request.addfinalizer(lambda: mozfile.remove(f.name))
+    return f.name
+
+
+def test_add_addon(qtbot, addons_editor, addons_file):
+    with patch("mozregui.addons_editor.QFileDialog") as dlg:
+        filePath = addons_file
+        dlg.getOpenFileNames.return_value = QStringList(filePath)
+        qtbot.mouseClick(
+            addons_editor.ui.add_addon,
+            Qt.LeftButton
+        )
+        dlg.getOpenFileNames.assert_called_once_with(
+            addons_editor,
+            "Choose one or more addon files",
+            filter="addon file (*.xpi)",
+        )
+
+        # check addons
+        assert addons_editor.list_model.rowCount() == len(
+            QStringList(filePath))
+        assert addons_editor.get_addons() == [filePath]
+
+
+def test_remove_addon(qtbot, addons_editor, addons_file):
+    test_add_addon(qtbot, addons_editor, addons_file)
+    addons_editor.ui.list_view.setCurrentIndex(addons_editor.list_model.index
+                                               (0))
+    assert addons_editor.ui.list_view.selectedIndexes()
+    qtbot.mouseClick(addons_editor.ui.remove_addon, Qt.LeftButton)
+
+    assert addons_editor.list_model.rowCount() == 0
+    assert addons_editor.get_addons() == []


### PR DESCRIPTION
Tested on OS X 10.10.4
***
(mozr)localhost:gui mikeling$ python build.py test
Executing `/Users/mikeling/mozregression/mozr/bin/flake8 mozregui build.py tests`
Running tests...
============================= test session starts ==============================
platform darwin -- Python 2.7.10 -- py-1.4.30 -- pytest-2.7.2 -- /Users/mikeling/mozregression/mozr/bin/python
qt-api: pyqt4
rootdir: /Users/mikeling/mozregression, inifile: 
plugins: qt
collected 8 items 

tests/test_addons_editor.py::test_creat_addons_editor PASSED
tests/test_addons_editor.py::test_add_addon PASSED
tests/test_addons_editor.py::test_remove_addon PASSED
tests/test_bisection.py::TestGuiBuildDownloadManager::test_focus_download PASSED
tests/test_bisection.py::TestGuiTestRunner::test_basic PASSED
tests/test_main.py::TestMain::test_persist_is_created_and_deleted PASSED
tests/test_report.py::test_report_basic PASSED
tests/test_wizard.py::test_wizard PASSED

=========================== 8 passed in 1.34 seconds ===========================
