### PR TITLE
Bug 1197128 - Create a dedicated data structure for build informations

### DIFF
--- a/gui/tests/test_bisection.py
+++ b/gui/tests/test_bisection.py
@@ -46,13 +46,13 @@ class TestGuiBuildDownloadManager(unittest.TestCase):
     def test_focus_download(self, extract_info):
         extract_info.return_value = ('http://foo', 'foo')
         mock_response(self.session_response, 'this is some data' * 10000, 0.01)
-        build_info = {}
+        build_info = Mock()
 
         with wait_signal(self.dl_manager.download_finished):
             self.dl_manager.focus_download(build_info)
 
         # build_path is defined
-        self.assertEquals(build_info['build_path'],
+        self.assertEquals(build_info.build_file,
                           self.dl_manager.get_dest('foo'))
 
         # signals have been emitted
@@ -61,7 +61,7 @@ class TestGuiBuildDownloadManager(unittest.TestCase):
         self.assertTrue(self.signals['download_progress'].call_count >= 2)
 
         # well, file has been downloaded finally
-        self.assertTrue(os.path.isfile(build_info['build_path']))
+        self.assertTrue(os.path.isfile(build_info.build_file))
 
 
 class TestGuiTestRunner(unittest.TestCase):

--- a/gui/tests/test_report.py
+++ b/gui/tests/test_report.py
@@ -1,6 +1,7 @@
 from PyQt4.QtCore import Qt
 from mock import Mock
 
+from mozregression.build_info import NightlyBuildInfo
 from mozregui.report import ReportView
 
 
@@ -23,10 +24,15 @@ def test_report_basic(qtbot):
     assert index.isValid()
 
     # simulate a build found
-    build_infos = {"build_type": 'nightly', 'build_date': 'date'}
+    data = dict(build_type='nightly', build_date='date')
+    build_infos = Mock(
+        spec=NightlyBuildInfo,
+        to_dict=lambda: data,
+        **data
+    )
     bisection = Mock()
     bisection.handler.find_fix = False
-    bisection.handler.get_range.return_value = (1, 2)
+    bisection.handler.get_range.return_value = ('1', '2')
     view.model().step_build_found(bisection, build_infos)
     # now we have two rows
     assert view.model().rowCount() == 2

--- a/mozregression/build_data.py
+++ b/mozregression/build_data.py
@@ -232,16 +232,6 @@ class MozBuildData(BuildData):
     def __init__(self, associated_data):
         BuildData.__init__(self, associated_data)
 
-    def _is_valid_build(self, build_info):
-        """
-        Indicate if a build folder is valid. By default, it check for the
-        existence of the build file and the build info file.
-
-        This must be used in :meth:`_get_valid_build` to ensure that a build
-        is valid.
-        """
-        return 'build_url' in build_info and 'build_txt_url' in build_info
-
     def _create_fetch_task(self, executor, i):
         return executor.submit(self._get_valid_build, i)
 
@@ -338,18 +328,9 @@ class InboundBuildData(MozBuildData):
     def _get_valid_build(self, i):
         changeset = self.get_associated_data(i)[0]
         try:
-            info = self.info_fetcher.find_build_info(changeset)
+            return self.info_fetcher.find_build_info(changeset)
         except errors.BuildInfoNotFound:
             return False
-        if self._is_valid_build(info):
-            return info
-        return False
-
-    def _set_data(self, i, data):
-        if data is not False:
-            data['timestamp'] = self.get_associated_data(i)[1]
-            data['revision'] = data['changeset'][:8]
-        MozBuildData._set_data(self, i, data)
 
 
 class NightlyBuildData(MozBuildData):

--- a/mozregression/build_info.py
+++ b/mozregression/build_info.py
@@ -1,0 +1,144 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+The BuildInfo classes, that are used to store information a build.
+"""
+
+
+FIELDS = []
+
+
+def export(func):
+    FIELDS.append(func.__name__)
+    return func
+
+
+class BuildInfo(object):
+    """
+    Store information about a build to be able to download and run it.
+
+    a BuildInfo is built by calling
+    :meth:`mozregression.fetch_build_info.FetchBuildInfo.find_build_info`.
+    """
+    def __init__(self, fetch_config, build_type, build_url, build_date,
+                 changeset, repo_url, repo_name):
+        self._fetch_config = fetch_config
+        self._build_type = build_type
+        self._build_url = build_url
+        self._build_date = build_date
+        self._changeset = changeset
+        self._repo_url = repo_url
+        self._repo_name = repo_name
+        self._build_file = None
+
+    @property
+    @export
+    def build_type(self):
+        """
+        Either 'nightly' or 'inbound'
+        """
+        return self._build_type
+
+    @property
+    @export
+    def app_name(self):
+        """
+        The application name, such as "firefox"
+        """
+        return self._fetch_config.app_name
+
+    @property
+    @export
+    def build_url(self):
+        """
+        The url to download the build
+        """
+        return self._build_url
+
+    @property
+    @export
+    def build_date(self):
+        """
+        The date of the build
+        """
+        return self._build_date
+
+    @property
+    @export
+    def changeset(self):
+        """
+        The changeset of the build. For old nightlies, this can be None.
+        """
+        return self._changeset
+
+    @property
+    @export
+    def repo_url(self):
+        """
+        The url of the repository. For old nightlies, this can be None.
+        """
+        return self._repo_url
+
+    @property
+    @export
+    def repo_name(self):
+        """
+        the repository name, e.g. 'mozilla-central'
+        """
+        return self._repo_name
+
+    @property
+    @export
+    def build_file(self):
+        """
+        The build file, once downloaded. This property is None when the
+        BuildInfo is instanciated and should be set later.
+        """
+        return self._build_file
+
+    @build_file.setter
+    def build_file(self, build_file):
+        self._build_file = build_file
+
+    @property
+    def short_changeset(self):
+        """
+        Returns the first 8 characters of the build changeset.
+        """
+        return self.changeset[:8]
+
+    def update_from_app_info(self, app_info):
+        """
+        Takes an app_info (as returned by mozversion) and update the build info
+        content if required.
+
+        This helps to build the pushlog url for old nightlies.
+        """
+        if self._changeset is None:
+            self._changeset = app_info.get('application_changeset')
+        if self._repo_url is None:
+            self._repo_url = app_info.get('application_repository')
+
+    def to_dict(self):
+        """
+        Export some public properties as a dict.
+        """
+        return dict((field, getattr(self, field)) for field in FIELDS)
+
+
+class NightlyBuildInfo(BuildInfo):
+    def __init__(self, fetch_config, build_url, build_date, changeset,
+                 repo_url):
+        BuildInfo.__init__(self, fetch_config, 'nightly', build_url,
+                           build_date, changeset, repo_url,
+                           fetch_config.get_nightly_repo(build_date))
+
+
+class InboundBuildInfo(BuildInfo):
+    def __init__(self, fetch_config, build_url, build_date, changeset,
+                 repo_url):
+        BuildInfo.__init__(self, fetch_config, 'inbound', build_url,
+                           build_date, changeset, repo_url,
+                           fetch_config.inbound_branch)

--- a/mozregression/download_manager.py
+++ b/mozregression/download_manager.py
@@ -287,14 +287,13 @@ class BuildDownloadManager(DownloadManager):
         self.background_dl_policy = background_dl_policy
 
     def _extract_download_info(self, build_info):
-        if build_info['build_type'] == 'nightly':
-            persist_prefix = str(build_info['build_date'])
-
+        if build_info.build_type == 'nightly':
+            persist_prefix = str(build_info.build_date)
         else:
-            persist_prefix = str(build_info['changeset'][:12])
+            persist_prefix = str(build_info.changeset[:12])
 
-        persist_prefix += '--%s--' % build_info['repo']
-        build_url = build_info['build_url']
+        persist_prefix += '--%s--' % build_info.repo_name
+        build_url = build_info.build_url
         fname = persist_prefix + os.path.basename(build_url)
         return build_url, fname
 

--- a/mozregression/test_runner.py
+++ b/mozregression/test_runner.py
@@ -31,17 +31,17 @@ class TestRunner(object):
         """
         Create and returns a :class:`mozregression.launchers.Launcher`.
         """
-        if build_info['build_type'] == 'nightly':
+        if build_info.build_type == 'nightly':
             self.logger.info("Running nightly for %s"
-                             % build_info["build_date"])
+                             % build_info.build_date)
         else:
-            self.logger.info("Testing inbound build with timestamp %s,"
+            self.logger.info("Testing inbound build built on %s,"
                              " revision %s"
-                             % (build_info['timestamp'],
-                                build_info['revision']))
+                             % (build_info.build_date,
+                                build_info.short_changeset))
 
-        return create_launcher(build_info['app_name'],
-                               build_info['build_path'])
+        return create_launcher(build_info.app_name,
+                               build_info.build_file)
 
     def evaluate(self, build_info, allow_back=False):
         """
@@ -57,17 +57,7 @@ class TestRunner(object):
         particular build.
 
         :param build_path: the path to the build file to test
-        :param build_info: is a dict containing information about the build
-                           to test. It is ensured to have the following keys:
-                            - build_type ('nightly' or 'inbound')
-                            - build_url
-                            - repository (mercurial repository of the build)
-                            - changeset (mercurial changeset of the build)
-                           Also, if the build_type is 'nightly':
-                            - build_date (datetime.date instance)
-                           Or 'inbound':
-                            - timestamp: timestamp of the build
-                            - revision (short version of changeset)
+        :param build_info: a :class:`mozrgression.uild_info.BuildInfo` instance
         :param allow_back: indicate if the back command should be proposed.
         """
         raise NotImplementedError
@@ -98,7 +88,7 @@ class ManualTestRunner(TestRunner):
         while verdict not in allowed_inputs:
             verdict = raw_input("Was this %s build good, bad, or broken?"
                                 " (type %s and press Enter): "
-                                % (build_info['build_type'],
+                                % (build_info.build_type,
                                    formatted_options))
 
         if verdict == 'back':
@@ -149,7 +139,8 @@ class CommandTestRunner(TestRunner):
     def evaluate(self, build_info, allow_back=False):
         launcher = self.create_launcher(build_info)
         app_info = launcher.get_app_info()
-        variables = dict((k, str(v)) for k, v in build_info.iteritems())
+        variables = dict((k, str(v))
+                         for k, v in build_info.to_dict().iteritems())
         if hasattr(launcher, 'binary'):
             variables['binary'] = launcher.binary
 

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -268,21 +268,21 @@ class TestBuildDownloadManager(unittest.TestCase):
                                                   session=self.session)
 
     def test__extract_download_info(self):
-        url, fname = self.dl_manager._extract_download_info({
+        url, fname = self.dl_manager._extract_download_info(Mock(**{
             'build_url': 'http://some/thing',
             'build_type': 'nightly',
             'build_date': date(2015, 01, 03),
-            'repo': 'my-repo',
-        })
+            'repo_name': 'my-repo',
+        }))
         self.assertEquals(url, 'http://some/thing')
         self.assertEquals(fname, '2015-01-03--my-repo--thing')
 
-        url, fname = self.dl_manager._extract_download_info({
+        url, fname = self.dl_manager._extract_download_info(Mock(**{
             'build_url': 'http://some/thing',
             'build_type': 'inbound',
             'changeset': '47856a21491834da3ab9b308145caa8ec1b98ee1',
-            'repo': 'my-repo',
-        })
+            'repo_name': 'my-repo',
+        }))
         self.assertEquals(url, 'http://some/thing')
         self.assertEquals(fname, '47856a214918--my-repo--thing')
 


### PR DESCRIPTION
This patch create BuildInfo classes (specialized to Nightly and Inbound)
to store build information.

It also change the way inbound testing is reported - instead of a timestamp,
it now report the build date (task cluster resolved date).