### PR TITLE
Bug 1185787 - Unable to bisect on preview releases of Android

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ DEPENDENCIES = [
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1212170
     'requests>=2.4.3,<3',
     'redo',
-    'mozdevice >= 0.46',
+    'mozdevice >= 0.47',
     'taskcluster>=0.0.29',
     'colorama',
     'configobj',


### PR DESCRIPTION
Fixed upstream in mozdevice.