### PR TITLE
Fixed bug #1195296, modified /mozregression/launchers.py

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -127,6 +127,8 @@ class Launcher(object):
     def create_profile(cls, profile=None, addons=(), preferences=None,
                        clone=True):
         if profile:
+            if not os.path.exists(profile):
+                os.makedirs(profile)
             if clone:
                 # mozprofile makes some changes in the profile that can not
                 # be undone. Let's clone the profile to not have side effect


### PR DESCRIPTION
Created a directory in the create_profile, if the specified profile path does not exist.