### PR TITLE
Fix Unicode display and edit

### DIFF
--- a/gui/mozregui/pref_editor.py
+++ b/gui/mozregui/pref_editor.py
@@ -30,13 +30,16 @@ class PreferencesModel(QAbstractTableModel):
             if index.column() == 0:
                 return name
             else:
-                return repr(value)
+                if isinstance(value, basestring):
+                    return '"' + value + '"'
+                else:
+                    return value
 
     def flags(self, index):
         return Qt.ItemIsSelectable | Qt.ItemIsEditable | Qt.ItemIsEnabled
 
     def setData(self, index, new_value, role=Qt.EditRole):
-        new_value = str(new_value.toString())
+        new_value = unicode(new_value.toString())
         name, value = self.prefs[index.row()]
         if index.column() == 0:
             # change pref name


### PR DESCRIPTION
This is a fix for Bug 1224083 - https://bugzilla.mozilla.org/show_bug.cgi?id=1224083 .

On line 39, the new_value object was a QVariant object, which can be converted to a QString.
Using QString's __str__( ) method seems to have solved the issue.