### PR TITLE
Bug 1217906 - allow to find build using build ids

### DIFF
--- a/mozregression/bisector.py
+++ b/mozregression/bisector.py
@@ -8,6 +8,7 @@ import math
 import datetime
 from mozlog.structured import get_default_logger
 
+from mozregression.dates import to_datetime
 from mozregression.build_range import range_for_inbounds, range_for_nightlies
 from mozregression.errors import MozRegressionError, LauncherError
 
@@ -211,7 +212,9 @@ class NightlyHandler(BisectorHandler):
         days = days_required - 1
         too_many_attempts = False
         max_attempts = 3
-        first_date = min(self.good_date, self.bad_date)
+        first_date = min(to_datetime(self.good_date),
+                         to_datetime(self.bad_date))
+
         while not infos or not infos.changeset:
             days += 1
             if days >= days_required + max_attempts:
@@ -219,7 +222,8 @@ class NightlyHandler(BisectorHandler):
                 break
             prev_date = first_date - datetime.timedelta(days=days)
             build_range = self.build_range
-            infos = build_range.build_info_fetcher.find_build_info(prev_date)
+            infos = build_range.build_info_fetcher.find_build_info(
+                prev_date.date())
         if days > days_required and not too_many_attempts:
             self._logger.info("At least one build folder was invalid, we have"
                               " to start from %d days ago." % days)

--- a/mozregression/build_info.py
+++ b/mozregression/build_info.py
@@ -5,6 +5,7 @@
 """
 The BuildInfo classes, that are used to store information a build.
 """
+import datetime
 from urlparse import urlparse
 
 
@@ -137,7 +138,10 @@ class BuildInfo(object):
         Compute and return the persist filename to use to store this build.
         """
         if self.build_type == 'nightly':
-            prefix = str(self.build_date)
+            if isinstance(self.build_date, datetime.datetime):
+                prefix = self.build_date.strftime("%Y-%m-%d-%H-%M-%S")
+            else:
+                prefix = str(self.build_date)
             persist_part = ''
         else:
             prefix = str(self.changeset[:12])

--- a/mozregression/build_range.py
+++ b/mozregression/build_range.py
@@ -13,6 +13,7 @@ import copy
 import datetime
 
 from threading import Thread
+from mozregression.dates import to_date
 from mozregression.errors import BuildInfoNotFound
 from mozregression.fetch_build_info import (InboundInfoFetcher,
                                             NightlyInfoFetcher)
@@ -164,11 +165,17 @@ def range_for_nightlies(fetch_config, start_date, end_date):
     """
     info_fetcher = NightlyInfoFetcher(fetch_config)
     futures_builds = []
-    for i in range((end_date - start_date).days + 1):
+    # build the build range using only dates
+    sd = to_date(start_date)
+    for i in range((to_date(end_date) - sd).days + 1):
         futures_builds.append(
             FutureBuildInfo(
                 info_fetcher,
-                start_date + datetime.timedelta(days=i)
+                sd + datetime.timedelta(days=i)
             )
         )
+    # and now put back the real start and end dates
+    # in case they were datetime instances (coming from buildid)
+    futures_builds[0].data = start_date
+    futures_builds[-1].data = end_date
     return BuildRange(info_fetcher, futures_builds)

--- a/mozregression/dates.py
+++ b/mozregression/dates.py
@@ -1,0 +1,47 @@
+"""
+Date utilities functions.
+"""
+
+import re
+import datetime
+
+from mozregression.errors import DateFormatError
+
+
+def parse_date(date_string):
+    """
+    Returns a date or a datetime from a string.
+    """
+    if len(date_string) == 14 and date_string.isdigit():
+        # probably a build id - transform that in a datetime
+        try:
+            return datetime.datetime.strptime(date_string, "%Y%m%d%H%M%S")
+        except ValueError:
+            raise DateFormatError(date_string)
+    regex = re.compile(r'(\d{4})\-(\d{1,2})\-(\d{1,2})')
+    matched = regex.match(date_string)
+    if not matched:
+        raise DateFormatError(date_string)
+    return datetime.date(int(matched.group(1)),
+                         int(matched.group(2)),
+                         int(matched.group(3)))
+
+
+def to_datetime(date):
+    """
+    transform a date to a datetime instance
+    If the parameter is not a date, it is returned without modification
+    """
+    if isinstance(date, datetime.date):
+        return datetime.datetime.combine(date, datetime.time())
+    return date
+
+
+def to_date(date_time):
+    """
+    transform a datetime to a date instance
+    If the parameter is not a datetime, it is returned without modification
+    """
+    if isinstance(date_time, datetime.datetime):
+        return date_time.date()
+    return date_time

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -176,6 +176,8 @@ class NightlyConfigMixin(object):
         """
         Returns the repo name for a given date.
         """
+        if isinstance(date, datetime.datetime):
+            date = date.date()
         return self.nightly_repo or self._get_nightly_repo(date)
 
     def _get_nightly_repo(self, date):
@@ -190,6 +192,10 @@ class NightlyConfigMixin(object):
         date.
         """
         repo = self.get_nightly_repo(date)
+        if isinstance(date, datetime.datetime):
+            return (r'^%04d-%02d-%02d-%02d-%02d-%02d-%s/$'
+                    % (date.year, date.month, date.day, date.hour,
+                       date.minute, date.second, repo))
         return (r'^%04d-%02d-%02d-[\d-]+%s/$'
                 % (date.year, date.month, date.day, repo))
 

--- a/mozregression/test_runner.py
+++ b/mozregression/test_runner.py
@@ -13,6 +13,7 @@ from mozlog.structured import get_default_logger
 import subprocess
 import shlex
 import os
+import datetime
 
 from mozregression.launchers import create_launcher
 from mozregression.errors import TestCommandError, LauncherError
@@ -32,8 +33,13 @@ class TestRunner(object):
         Create and returns a :class:`mozregression.launchers.Launcher`.
         """
         if build_info.build_type == 'nightly':
-            self.logger.info("Running nightly for %s"
-                             % build_info.build_date)
+            if isinstance(build_info.build_date, datetime.datetime):
+                self.logger.info("Running nightly for buildid %s"
+                                 % build_info.build_date.strftime(
+                                     "%Y%m%d%H%M%S"))
+            else:
+                self.logger.info("Running nightly for %s"
+                                 % build_info.build_date)
         else:
             self.logger.info("Testing inbound build built on %s,"
                              " revision %s"

--- a/tests/unit/test_build_info.py
+++ b/tests/unit/test_build_info.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import date
+from datetime import date, datetime
 
 from mozregression.fetch_configs import create_config
 from mozregression import build_info
@@ -99,6 +99,10 @@ def test_to_dict(klass):
     (build_info.NightlyBuildInfo,
      {},
      '2015-09-01--mozilla-central--url'),
+    # this time with a datetime instance (buildid)
+    (build_info.NightlyBuildInfo,
+     {'build_date': datetime(2015, 11, 16, 10, 2, 5)},
+     '2015-11-16-10-02-05--mozilla-central--url'),
     # same but for inbound
     (build_info.InboundBuildInfo,
      {},

--- a/tests/unit/test_build_range.py
+++ b/tests/unit/test_build_range.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import date
+from datetime import date, datetime
 
 from mozregression import build_range
 from mozregression.fetch_build_info import InfoFetcher
@@ -138,3 +138,25 @@ def test_range_for_nightlies():
     assert b_range[0] == date(2015, 01, 01)
     assert b_range[1] == date(2015, 01, 02)
     assert b_range[2] == date(2015, 01, 03)
+
+
+@pytest.mark.parametrize('start,end,range_size', [
+    (datetime(2015, 11, 16, 10, 2, 5), date(2015, 11, 19), 4),
+    (date(2015, 11, 14), datetime(2015, 11, 16, 10, 2, 5), 3),
+    (datetime(2015, 11, 16, 10, 2, 5),
+     datetime(2015, 11, 20, 11, 4, 9), 5),
+])
+def test_range_for_nightlies_datetime(start, end, range_size):
+    fetch_config = create_config('firefox', 'linux', 64)
+
+    b_range = build_range.range_for_nightlies(fetch_config, start, end)
+
+    assert isinstance(b_range, build_range.BuildRange)
+    assert len(b_range) == range_size
+
+    b_range.build_info_fetcher.find_build_info = lambda v: v
+    assert b_range[0] == start
+    assert b_range[-1] == end
+    # between, we only have date instances
+    for i in range(1, range_size - 1):
+        assert isinstance(b_range[i], date)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,9 +21,16 @@ class TestParseDate(unittest.TestCase):
         date = cli.parse_date("2014-07-05")
         self.assertEquals(date, datetime.date(2014, 7, 5))
 
+    def test_parse_buildid(self):
+        date = cli.parse_date("20151103030248")
+        self.assertEquals(date, datetime.datetime(2015, 11, 3, 3, 2, 48))
+
     def test_invalid_date(self):
         self.assertRaises(errors.DateFormatError, cli.parse_date,
                           "invalid_format")
+        # test invalid buildid (43 is not a valid day)
+        self.assertRaises(errors.DateFormatError, cli.parse_date,
+                          "20151143030248")
 
 
 class TestParseBits(unittest.TestCase):

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -50,6 +50,10 @@ class TestFirefoxConfigLinux64(unittest.TestCase):
         repo_regex = self.conf.get_nightly_repo_regex(datetime.date(2008,
                                                                     6, 27))
         self.assertEqual(repo_regex, '^2008-06-27-[\\d-]+mozilla-central/$')
+        # test with a datetime instance (buildid)
+        repo_regex = self.conf.get_nightly_repo_regex(
+            datetime.datetime(2015, 11, 27, 6, 5, 58))
+        self.assertEqual(repo_regex, '^2015-11-27-06-05-58-mozilla-central/$')
 
     def test_set_nightly_repo(self):
         self.conf.set_nightly_repo('foo-bar')

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -6,6 +6,7 @@
 
 import pytest
 import unittest
+import datetime
 from mock import patch, Mock
 
 from mozregression import test_runner, errors, build_info
@@ -43,6 +44,25 @@ class TestManualTestRunner(unittest.TestCase):
         result_launcher = self.runner.create_launcher(info)
         create_launcher.\
             assert_called_with(info)
+
+        self.assertEqual(result_launcher, launcher)
+
+    @patch('mozregression.test_runner.create_launcher')
+    def test_nightly_create_launcher_buildid(self, create_launcher):
+        launcher = Mock()
+        create_launcher.return_value = launcher
+        info = mockinfo(
+            build_type='nightly',
+            app_name="firefox",
+            build_file="/path/to",
+            build_date=datetime.datetime(2015, 11, 6, 5, 4, 3),
+        )
+        self.runner.logger.info = Mock()
+        result_launcher = self.runner.create_launcher(info)
+        create_launcher.\
+            assert_called_with(info)
+        self.runner.logger.info.assert_called_with(
+            'Running nightly for buildid 20151106050403')
 
         self.assertEqual(result_launcher, launcher)
 


### PR DESCRIPTION
This allow in --good-date, --bad-date, --launch to use a given buildid.

It works for nightlies only, as finding the buildid relies on the folder
name in archives.m.o.

A known bug is that files are stored using the build id, so it is
possible to have two files downloaded and kept in the persist dir
that are identical, example:

2015-11-03-03-02-48--mozilla-central--firefox-45.0a1.en-US.linux-x86_64.tar.bz2
2015-11-03--mozilla-central--firefox-45.0a1.en-US.linux-x86_64.tar.bz2