### PR TITLE
Bug 1225544 - make use of the build flavor options for nightlies

### DIFF
--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -435,9 +435,11 @@ class Configuration(object):
         if fetch_config.is_inbound():
             fetch_config.set_inbound_branch(options.repo)
 
-        # we need to use taskcluser for integration branches and b2g
+        # we need to use taskcluser for integration branches and b2g,
+        # or if we are looking for a specific build flavor
         use_taskcluster = (branches.get_category(options.repo) == 'integration'
-                           or fetch_config.is_b2g_device())
+                           or fetch_config.is_b2g_device()
+                           or fetch_config.build_type != 'opt')
 
         if not user_defined_bits and \
                 options.bits == 64 and \

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -213,6 +213,9 @@ SOME_OLDER_DATE = TODAY + datetime.timedelta(days=-10)
     (['--good=%s' % SOME_DATE, '--bad=%s' % SOME_OLDER_DATE, '--repo=m-c',
       '--app=b2g-emulator'],
      SOME_DATE, SOME_OLDER_DATE),
+    # non opt build flavors are also found using taskcluster
+    (['--good=%s' % SOME_DATE, '--bad=%s' % SOME_OLDER_DATE, '-B', 'debug'],
+     SOME_DATE, SOME_OLDER_DATE)
 ])
 def test_use_taskcluster_bisection_method(params, good, bad):
     config = do_cli(*params)


### PR DESCRIPTION
Basically use taskcluster when any specific build flavor is
asked (!= 'opt'). This allow the command
|mozregression -g 2015-11-20 -b 2015-11-22 -B debug| to work as expected.