### PR TITLE
Bug 1228951 - only use --good/--bad parameters

### DIFF
--- a/mozregression/json_pushes.py
+++ b/mozregression/json_pushes.py
@@ -90,6 +90,10 @@ class JsonPushes(object):
         return the first revision pushed on that date.
         """
         enddate = date + datetime.timedelta(days=1)
+        if last:
+            # check a range starting 4 days before - in case we are on Monday,
+            # we will be able to get changesets from the last Friday.
+            date += datetime.timedelta(days=-4)
         url = '%s/json-pushes?startdate=%s&enddate=%s' % (
             self.repo_url(),
             date.strftime('%Y-%m-%d'),

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -110,7 +110,7 @@ class Application(object):
         return self._build_download_manager
 
     def bisect_nightlies(self):
-        good_date, bad_date = self.options.good_date, self.options.bad_date
+        good_date, bad_date = self.options.good, self.options.bad
         handler = NightlyHandler(find_fix=self.options.find_fix)
         result = self._do_bisect(handler, good_date, bad_date)
         if result == Bisection.FINISHED:
@@ -133,8 +133,7 @@ class Application(object):
         return 0
 
     def bisect_inbounds(self):
-        return self._bisect_inbounds(self.options.last_good_revision,
-                                     self.options.first_bad_revision)
+        return self._bisect_inbounds(self.options.good, self.options.bad)
 
     def _bisect_inbounds(self, good_rev, bad_rev):
         self._logger.info("Getting inbound builds between %s and %s"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -126,8 +126,8 @@ def test_app_bisect_nightlies_no_data(create_app):
 @pytest.mark.parametrize("same_chsets", [True, False])
 def test_app_bisect_inbounds_finished(create_app, same_chsets):
     argv = [
-        '--good-rev=c1',
-        '--bad-rev=%s' % ('c1' if same_chsets else 'c2')
+        '--good=c1',
+        '--bad=%s' % ('c1' if same_chsets else 'c2')
     ]
     app = create_app(argv)
     app.bisector.bisect = Mock(return_value=Bisection.FINISHED)
@@ -174,7 +174,7 @@ def test_app_bisect_inbounds_user_exit(create_app, mocker):
                                 bad_revision='c2',
                                 spec=InboundHandler)
 
-    app = create_app(['--good-rev=c1', '--bad-rev=c2'])
+    app = create_app(['--good=c1', '--bad=c2'])
     app.bisector.bisect = Mock(return_value=Bisection.USER_EXIT)
     assert app.bisect_inbounds() == 0
     assert create_app.find_in_log("To resume, run:")
@@ -182,7 +182,7 @@ def test_app_bisect_inbounds_user_exit(create_app, mocker):
 
 
 def test_app_bisect_inbounds_no_data(create_app):
-    app = create_app(['--good-rev=c1', '--bad-rev=c2'])
+    app = create_app(['--good=c1', '--bad=c2'])
     app.bisector.bisect = Mock(return_value=Bisection.NO_DATA)
     assert app.bisect_inbounds() == 1
     assert create_app.find_in_log(
@@ -281,7 +281,7 @@ class TestMain(unittest.TestCase):
 
     def test_bisect_inbounds(self):
         self.app.bisect_inbounds.return_value = 0
-        exitcode = self.do_cli(['--good-rev=1', '--bad-rev=5'])
+        exitcode = self.do_cli(['--good=a1', '--bad=b5'])
         self.assertEqual(exitcode, 0)
         self.app.bisect_inbounds.assert_called_with()
 


### PR DESCRIPTION
Removes --good-release, --bad-release, --good-rev, --bad-rev and allow
--good and --bad to take any kind of range limit (a date, build id,
release number or changeset). Same possible values as for the --launch option.