### PR TITLE
Bug 1231745 - fix race condition when removing dl dir

### DIFF
--- a/mozregression/download_manager.py
+++ b/mozregression/download_manager.py
@@ -250,6 +250,13 @@ class DownloadManager(object):
                     if download.is_running():
                         download.cancel()
 
+    def wait(self, raise_if_error=True):
+        """
+        Wait for all downloads to be finished.
+        """
+        for download in self._downloads.values():
+            download.wait(raise_if_error=raise_if_error)
+
     def download(self, url, fname):
         """
         Returns a started download instance, or None if fname is already

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -66,6 +66,13 @@ class Application(object):
             # cancel all possible downloads
             self._build_download_manager.cancel()
         if self._rm_download_dir:
+            if self._build_download_manager:
+                # we need to wait explicitly for downloading threads completion
+                # here because it may remove a file in the download dir - and
+                # in that case we could end up with a race condition when
+                # we will remove the download dir. See
+                # https://bugzilla.mozilla.org/show_bug.cgi?id=1231745
+                self._build_download_manager.wait(raise_if_error=False)
             mozfile.remove(self._download_dir)
         if self._global_profile \
            and self.options.profile_persistence == 'clone-first':


### PR DESCRIPTION
Ensure that we don't have a race condition when the download_dir is
removed by first waiting for download threads to be finished.