### PR TITLE
[gui] Bisection Informations context menu text turns white when hovered

### DIFF
--- a/gui/mozregui/report.py
+++ b/gui/mozregui/report.py
@@ -299,7 +299,6 @@ class BuildInfoTextBrowser(QTextBrowser):
             return
 
         html = ""
-        self.setStyleSheet("background-color:%s;" % GRAY_WHITE.name())
         for k in sorted(item.data):
             v = item.data[k]
             html += '<strong>%s</strong>: ' % k


### PR DESCRIPTION
Removed the unnecessary setStyleSheet() call