### PR TITLE
Bug 1234029 - use debug builds from archives.m.o

### DIFF
--- a/mozregression/build_info.py
+++ b/mozregression/build_info.py
@@ -142,7 +142,7 @@ class BuildInfo(object):
                 prefix = self.build_date.strftime("%Y-%m-%d-%H-%M-%S")
             else:
                 prefix = str(self.build_date)
-            persist_part = ''
+            persist_part = self._fetch_config.nightly_persist_part()
         else:
             prefix = str(self.changeset[:12])
             persist_part = self._fetch_config.inbound_persist_part()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -209,9 +209,6 @@ SOME_OLDER_DATE = TODAY + datetime.timedelta(days=-10)
     (['--good=%s' % SOME_DATE, '--bad=%s' % SOME_OLDER_DATE, '--repo=m-c',
       '--app=b2g-emulator'],
      SOME_DATE, SOME_OLDER_DATE),
-    # non opt build flavors are also found using taskcluster
-    (['--good=%s' % SOME_DATE, '--bad=%s' % SOME_OLDER_DATE, '-B', 'debug'],
-     SOME_DATE, SOME_OLDER_DATE)
 ])
 def test_use_taskcluster_bisection_method(params, good, bad):
     config = do_cli(*params)

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -319,5 +319,32 @@ def test_jsshell_build_regex(os, bits, name):
     assert re.match(conf.build_regex(), name)
 
 
+@pytest.mark.parametrize('appname,build_type,persist_part', [
+    ('firefox', 'opt', ''),
+    ('firefox', 'debug', 'debug'),
+    ('jsshell', 'opt', ''),
+    ('jsshell', 'debug', 'debug'),
+    ('fennec', 'opt', ''),
+])
+def test_nightly_handle_build_type(appname, build_type, persist_part):
+    conf = create_config(appname, 'linux', 64)
+    conf.set_build_type(build_type)
+    assert conf.nightly_persist_part() == persist_part
+    assert conf.nightly_handle_build_type()
+
+
+@pytest.mark.parametrize('appname,build_type,date,branch,match_sample', [
+    ('firefox', 'debug', datetime.date(2014, 8, 1), 'mozilla-central',
+     '2014-08-01-mozilla-central-debug/'),
+    ('firefox', 'debug', datetime.date(2014, 8, 1), 'aurora',
+     '2014-08-01-mozilla-aurora-debug/'),
+])
+def test_get_nightly_repo_regex_with_build_type(appname, build_type, date,
+                                                branch, match_sample):
+    conf = create_config(appname, 'linux', 64)
+    conf.set_build_type(build_type)
+    conf.set_repo(branch)
+    assert re.match(conf.get_nightly_repo_regex(date), match_sample)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For firefox and jsshell, provides access to debug builds using
archives.m.o.

Those builds are stored using 'debug' in their filename, and
using TaskCluster is not required anymore.
