### PR TITLE
Bug1234603 - [gui] Added Show/Hide Advanced Options button in global prefs dialog

### DIFF
--- a/gui/mozregui/global_prefs.py
+++ b/gui/mozregui/global_prefs.py
@@ -54,6 +54,23 @@ class ChangePrefsDialog(QDialog):
         self.ui.http_timeout.setValue(options['http_timeout'])
         self.ui.persist_size_limit.setValue(options['persist_size_limit'])
         self.ui.bg_downloads.setChecked(options['background_downloads'])
+        self.ui.advanced_options.setText("Show Advanced Options")
+        self.toggle_visibility(False)
+        self.ui.advanced_options.clicked.connect(self.toggle_adv_options)
+
+    def toggle_adv_options(self):
+        if self.ui.advanced_options.text() == "Show Advanced Options":
+            self.ui.advanced_options.setText("Hide Advanced Options")
+            self.toggle_visibility(True)
+        else:
+            self.ui.advanced_options.setText("Show Advanced Options")
+            self.toggle_visibility(False)
+
+    def toggle_visibility(self, visible):
+        self.ui.http_timeout.setVisible(visible)
+        self.ui.label_3.setVisible(visible)
+        self.ui.bg_downloads.setVisible(visible)
+        self.ui.label_2.setVisible(visible)
 
     def save_prefs(self):
         options = get_prefs()

--- a/gui/mozregui/ui/global_prefs.ui
+++ b/gui/mozregui/ui/global_prefs.ui
@@ -89,14 +89,38 @@
     </layout>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
+    <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>54</height>
+      </size>
      </property>
-    </widget>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="advanced_options">
+       <property name="text">
+        <string>Show Advanced Options</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Added a 'Show Advanced Options' button in the global preferences dialog. Initially, `http timeout` and `background downloads` options are hidden. On clicking the button, the button's text changes to 'Hide Advanced Options' and the advanced options become visible.