### PR TITLE
Pass package name to ADBAndroid.process_exist

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -324,7 +324,7 @@ class FennecLauncher(Launcher):
                                extra_args=["-profile", self.remote_profile])
 
     def _wait(self):
-        while self.adb.process_exist():
+        while self.adb.process_exist(self.package_name):
             time.sleep(0.1)
 
     def _stop(self):

--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -253,7 +253,7 @@ class TestFennecLauncher(unittest.TestCase):
 
         passed = []
 
-        def proc_exists():
+        def proc_exists(name):
             # return True one time, then False
             result = not bool(passed)
             passed.append(1)
@@ -262,7 +262,7 @@ class TestFennecLauncher(unittest.TestCase):
         self.adb.process_exist = Mock(side_effect=proc_exists)
         launcher.start()
         launcher.wait()
-        self.adb.process_exist.assert_called_with()
+        self.adb.process_exist.assert_called_with('org.mozilla.fennec')
 
 
 class Zipfile(object):


### PR DESCRIPTION
Fixes an uncaught exception when running Fennec:

```
$ mozregression --app fennec --launch 2015-10-29
 0:01.10 LOG: MainThread download INFO Using local file: /home/mbrubeck/.mozilla/mozregression/persist/2015-10-29--mozilla-central--fennec-45.0a1.multi.android-arm.apk
 0:01.10 LOG: MainThread Test Runner INFO Running mozilla-central build for 2015-10-29
 0:01.15 LOG: MainThread mozversion INFO application_buildid: 20151029045227
 0:01.15 LOG: MainThread mozversion INFO application_changeset: acb3f4ac5424181d3d4d73283668162137918cf1
 0:01.15 LOG: MainThread mozversion INFO application_name: Fennec
 0:01.15 LOG: MainThread mozversion INFO application_repository: https://hg.mozilla.org/mozilla-central
 0:01.15 LOG: MainThread mozversion INFO application_version: 45.0a1
 0:01.15 LOG: MainThread mozversion INFO package_name: org.mozilla.fennec
Traceback (most recent call last):
  File "mozregression/main.py", line 305, in <module>
    main()
  File "mozregression/main.py", line 285, in main
    sys.exit(method())
  File "mozregression/main.py", line 233, in launch_nightlies
    self._launch(NightlyInfoFetcher)
  File "mozregression/main.py", line 230, in _launch
    self.test_runner.run_once(build_info)
  File "/home/mbrubeck/src/mozregression/mozregression/test_runner.py", line 135, in run_once
    return launcher.wait()
  File "/home/mbrubeck/src/mozregression/mozregression/launchers.py", line 77, in wait
    return_code = self._wait()
  File "/home/mbrubeck/src/mozregression/mozregression/launchers.py", line 327, in _wait
    while self.adb.process_exist():
TypeError: process_exist() takes at least 2 arguments (1 given)
```