### PR TITLE
ADBHost().devices() now raises ADBError instead of OSError

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -291,9 +291,8 @@ class FennecLauncher(Launcher):
     def check_is_runnable(cls):
         try:
             devices = ADBHost().devices()
-        except ADBError:
-            raise LauncherNotRunnable("mozdevice.adb.ADBError: [Errno 2] No"
-                                      " such file or directory: adb is not executable.")
+        except ADBError as adb_error:
+            raise LauncherNotRunnable(str(adb_error))
         if not devices:
             raise LauncherNotRunnable("No android device connected."
                                       " Connect a device and try again.")

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -289,13 +289,13 @@ class FennecLauncher(Launcher):
 
     @classmethod
     def check_is_runnable(cls):
-        # ADBHost().devices() seems to raise OSError when adb is not
-        # installed and in PATH. TODO: maybe fix this in mozdevice.
+        # ADBHost().devices() seems to raise ADBError
+        # when adb is not executable or not in PATH.
         try:
             devices = ADBHost().devices()
-        except OSError:
+        except ADBError:
             raise LauncherNotRunnable("adb (Android Debug Bridge) is not"
-                                      " installed or not in the PATH.")
+                                      " executable or not in the PATH.")
         if not devices:
             raise LauncherNotRunnable("No android device connected."
                                       " Connect a device and try again.")

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -289,13 +289,11 @@ class FennecLauncher(Launcher):
 
     @classmethod
     def check_is_runnable(cls):
-        # ADBHost().devices() seems to raise ADBError
-        # when adb is not executable or not in PATH.
         try:
             devices = ADBHost().devices()
         except ADBError:
-            raise LauncherNotRunnable("adb (Android Debug Bridge) is not"
-                                      " executable or not in the PATH.")
+            raise LauncherNotRunnable("mozdevice.adb.ADBError: [Errno 2] No"
+                                      " such file or directory: adb is not executable.")
         if not devices:
             raise LauncherNotRunnable("No android device connected."
                                       " Connect a device and try again.")

--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -8,6 +8,7 @@ import mozfile
 from mock import patch, Mock, ANY
 from mozprofile import Profile
 from mozregression.errors import LauncherNotRunnable, LauncherError
+from mozdevice import ADBError
 
 
 class MyLauncher(launchers.Launcher):
@@ -243,7 +244,7 @@ class TestFennecLauncher(unittest.TestCase):
                           launchers.FennecLauncher.check_is_runnable)
 
         # or if ADBHost().devices() raise an unexpected IOError
-        devices.side_effect = OSError()
+        devices.side_effect = ADBError()
         self.assertRaises(LauncherNotRunnable,
                           launchers.FennecLauncher.check_is_runnable)
 


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1236469#c3