### PR TITLE
Fix pkg_resources.DistributionNotFound: The 'pytest' distribution was…

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 coverage
 mock
 flake8
+pytest
 
 # install mozregression
 -e .


### PR DESCRIPTION
… not found

## Steps to reproduce
If you have never installed the project:

1. Go to the project folder
1. Create a virtual env
1. `pip install -r requirements-dev.txt`
1. `./check.py`

If you already have:

1. `deactivate; rm -rf .env .eggs` 
1. Then do the steps described in the first paragraph

## Results
If you have never cached pytest, you end up with this stacktrace: 
```
Installed /home/jlorenzo/git/mozregression/.eggs/pytest_mock-0.9.0-py2.7.egg
Traceback (most recent call last):
  File "setup.py", line 77, in <module>
    'Operating System :: OS Independent'
  File "/usr/lib64/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib64/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/jlorenzo/git/mozregression/.env/lib/python2.7/site-packages/setuptools/command/test.py", line 134, in run
    self.distribution.fetch_build_eggs(self.distribution.tests_require)
  File "/home/jlorenzo/git/mozregression/.env/lib/python2.7/site-packages/setuptools/dist.py", line 313, in fetch_build_eggs
    replace_conflicting=True,
  File "/home/jlorenzo/git/mozregression/.env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 839, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pytest' distribution was not found and is required by the application
Traceback (most recent call last):
  File "./check.py", line 57, in <module>
    run(test_run_cmd + ['setup.py', 'test'])
  File "./check.py", line 31, in run
    check_call(cmd, **kwargs)
  File "/usr/lib64/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['python', 'setup.py', 'test']' returned non-zero exit status 1
```