### PR TITLE
Bug 1240393 - [gui] Mozregression can't restart a build

### DIFF
--- a/gui/mozregui/build_runner.py
+++ b/gui/mozregui/build_runner.py
@@ -164,6 +164,7 @@ class AbstractBuildRunner(QObject):
         self.thread.start()
         # this will be called in the worker thread.
         QTimer.singleShot(0, action)
+        self.stopped = False
         self.running_state_changed.emit(True)
 
     @Slot()


### PR DESCRIPTION
This fix a bug that prevented a build to be launched after user cancellation.