### PR TITLE
Geckov2

### DIFF
--- a/gui/mozregui/wizard.py
+++ b/gui/mozregui/wizard.py
@@ -91,7 +91,7 @@ class IntroPage(WizardPage):
         self.fetch_config = create_config(app_name, mozinfo.os, bits)
 
         self.build_type_model = QStringListModel(
-            [i for i in REGISTRY.get(app_name).BUILD_TYPES])
+            self.fetch_config.available_build_types())
         self.ui.build_type.setModel(self.build_type_model)
 
         if not self.fetch_config.available_bits():

--- a/mozregression/build_range.py
+++ b/mozregression/build_range.py
@@ -48,6 +48,16 @@ class FutureBuildInfo(object):
         return self._build_info is not False
 
 
+class TCFutureBuildInfo(FutureBuildInfo):
+    def __init__(self, build_info_fetcher, data, push_date):
+        FutureBuildInfo.__init__(self, build_info_fetcher, data)
+        self.push_date = push_date
+
+    def _fetch(self):
+        return self.build_info_fetcher.find_build_info(self.data,
+                                                       self.push_date)
+
+
 class BuildRange(object):
     """
     Range of build infos used in bisection.
@@ -187,7 +197,8 @@ def range_for_inbounds(fetch_config, start_rev, end_rev, time_limit=None):
     futures_builds = []
     for pushlog in pushlogs:
         changeset = pushlog['changesets'][-1]
-        futures_builds.append(FutureBuildInfo(info_fetcher, changeset))
+        futures_builds.append(TCFutureBuildInfo(info_fetcher, changeset,
+                                                pushlog['date']))
     return BuildRange(info_fetcher, futures_builds)
 
 

--- a/mozregression/dates.py
+++ b/mozregression/dates.py
@@ -4,6 +4,7 @@ Date utilities functions.
 
 import re
 import datetime
+import calendar
 
 from mozregression.errors import DateFormatError
 
@@ -49,3 +50,7 @@ def to_date(date_time):
 
 def is_date_or_datetime(obj):
     return isinstance(obj, (datetime.date, datetime.datetime))
+
+
+def to_utc_timestamp(date_time):
+    return calendar.timegm(date_time.timetuple())

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -497,6 +497,7 @@ class B2GEmulatorConfig(B2GAriesConfig):
 class FennecConfig(CommonConfig,
                    FennecNightlyConfigMixin,
                    FennecInboundConfigMixin):
+    BUILD_TYPES = ('opt', 'debug')
 
     def build_regex(self):
         return r'fennec-.*\.apk'

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -34,13 +34,14 @@ NIGHTLY_BASE_URL = "https://archive.mozilla.org/pub"
 TIMESTAMP_GECKO_V2 = to_utc_timestamp(datetime.datetime(2015, 10, 1, 1, 1, 1))
 
 
-def get_build_regex(name, os, bits, with_ext=True):
+def get_build_regex(name, os, bits, psuffix='', with_ext=True):
     """
     Returns a string regexp that can match a build filename.
 
     :param name: must be the beginning of the filename to match
     :param os: the os, as returned by mozinfo.os
     :param bits: the bits information of the build. Either 32 or 64.
+    :param psuffix: optional suffix before the extension
     :param with_ext: if True, the build extension will be appended (either
                      .zip, .tar.bz2 or .dmg depending on the os).
     """
@@ -62,7 +63,7 @@ def get_build_regex(name, os, bits, with_ext=True):
             " os is reported as '%s'." % os
         )
 
-    regex = '%s%s' % (name, suffix)
+    regex = '%s%s%s' % (name, suffix, psuffix)
     if with_ext:
         return '%s%s' % (regex, ext)
     else:
@@ -173,7 +174,9 @@ class CommonConfig(object):
         """
         return (branches.get_category(self.repo) in ('integration', 'try') or
                 self.is_b2g_device() or
-                self.build_type != 'opt')
+                # we can find the asan builds (firefox and jsshell) in
+                # archives.m.o
+                self.build_type not in ('opt', 'asan'))
 
 
 class NightlyConfigMixin(object):
@@ -427,7 +430,14 @@ def create_config(name, os, bits):
 class FirefoxConfig(CommonConfig,
                     FireFoxNightlyConfigMixin,
                     FirefoxInboundConfigMixin):
-    BUILD_TYPES = ('opt', 'debug', 'pgo[linux32,linux64,win32,win64]')
+    BUILD_TYPES = ('opt', 'debug', 'pgo[linux32,linux64,win32,win64]',
+                   'asan[linux64]', 'asan-debug[linux64]')
+
+    def build_regex(self):
+        return get_build_regex(
+            self.app_name, self.os, self.bits,
+            psuffix='-asan' if 'asan' in self.build_type else ''
+        ) + '$'
 
 
 @REGISTRY.register('thunderbird')
@@ -532,4 +542,5 @@ class JsShellConfig(FirefoxConfig):
                 part = 'win32'
         else:
             part = 'mac'
-        return r'jsshell-%s\.zip$' % part
+        psuffix = '-asan' if 'asan' in self.build_type else ''
+        return r'jsshell-%s%s\.zip$' % (part, psuffix)

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -19,6 +19,7 @@ an instance of :class:`ClassRegistry`. Example: ::
 
   print REGISTRY.names()
 """
+import re
 import datetime
 
 from mozregression.class_registry import ClassRegistry
@@ -119,6 +120,20 @@ class CommonConfig(object):
         """
         return (32, 64)
 
+    def available_build_types(self):
+        res = []
+        for available in self.BUILD_TYPES:
+            match = re.match("(.+)\[(.+)\]", available)
+            if match:
+                available = match.group(1)
+                platforms = match.group(2)
+                if '{}{}'.format(self.os,
+                                 self.bits) not in platforms.split(','):
+                    available = None
+            if available:
+                res.append(available)
+        return res
+
     def set_build_type(self, build_type):
         """
         Define the build types (opt, debug, eng, jb, asan...).
@@ -130,7 +145,7 @@ class CommonConfig(object):
         :raises: MozRegressionError on error.
         """
         flavors = set(_extract_build_type(build_type))
-        for available in self.BUILD_TYPES:
+        for available in self.available_build_types():
             if flavors == set(available.split('-')):
                 self.build_type = available
                 return
@@ -412,7 +427,7 @@ def create_config(name, os, bits):
 class FirefoxConfig(CommonConfig,
                     FireFoxNightlyConfigMixin,
                     FirefoxInboundConfigMixin):
-    BUILD_TYPES = ('opt', 'debug')
+    BUILD_TYPES = ('opt', 'debug', 'pgo[linux32,linux64,win32,win64]')
 
 
 @REGISTRY.register('thunderbird')

--- a/mozregression/json_pushes.py
+++ b/mozregression/json_pushes.py
@@ -112,16 +112,16 @@ class JsonPushes(object):
 
     def revision_for_date(self, date):
         """
-        Returns the last revision that matches the given date.
+        Returns the last couple (revision, push_date) that matches the given
+        date.
 
         Raise an explicit EmptyPushlogError if no pushes are available.
         """
         try:
-            return self.pushlog_within_changes(
-                date, date, verbose=False
-            )[-1]['changesets'][-1]
+            push = self.pushlog_within_changes(date, date, verbose=False)[-1]
         except EmptyPushlogError:
             raise EmptyPushlogError(
                 "No pushes available for the date %s on %s."
                 % (date, self.branch)
             )
+        return push['changesets'][-1], push['date']

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -243,10 +243,9 @@ class Application(object):
         handler.print_range()
         self._print_resume_info(handler)
 
-    def _launch(self, fetcher_class, **fetch_kwargs):
+    def _launch(self, fetcher_class):
         fetcher = fetcher_class(self.fetch_config)
-        build_info = fetcher.find_build_info(self.options.launch,
-                                             **fetch_kwargs)
+        build_info = fetcher.find_build_info(self.options.launch)
         self.build_download_manager.focus_download(build_info)
         self.test_runner.run_once(build_info)
 
@@ -254,7 +253,7 @@ class Application(object):
         self._launch(NightlyInfoFetcher)
 
     def launch_inbound(self):
-        self._launch(InboundInfoFetcher, check_changeset=True)
+        self._launch(InboundInfoFetcher)
 
 
 def pypi_latest_version():

--- a/tests/unit/test_build_range.py
+++ b/tests/unit/test_build_range.py
@@ -100,9 +100,9 @@ def test_range_for_inbounds(mocker):
     jpush_class = mocker.patch('mozregression.fetch_build_info.JsonPushes')
     jpush = mocker.Mock(
         pushlog_within_changes=mocker.Mock(
-            return_value=[{'changesets': ['a', 'b']},
-                          {'changesets': ['c', 'd']},
-                          {'changesets': ['e', 'f']}]
+            return_value=[{'changesets': ['a', 'b'], 'date': 1},
+                          {'changesets': ['c', 'd'], 'date': 2},
+                          {'changesets': ['e', 'f'], 'date': 3}]
         ),
         spec=JsonPushes
     )
@@ -115,10 +115,10 @@ def test_range_for_inbounds(mocker):
     assert isinstance(b_range, build_range.BuildRange)
     assert len(b_range) == 3
 
-    b_range.build_info_fetcher.find_build_info = lambda v: v
-    assert b_range[0] == 'b'
-    assert b_range[1] == 'd'
-    assert b_range[2] == 'f'
+    b_range.build_info_fetcher.find_build_info = lambda v, d: (v, d)
+    assert b_range[0] == ('b', 1)
+    assert b_range[1] == ('d', 2)
+    assert b_range[2] == ('f', 3)
 
 
 DATE_NOW = datetime.now()

--- a/tests/unit/test_fetch_build_info.py
+++ b/tests/unit/test_fetch_build_info.py
@@ -141,7 +141,7 @@ class TestInboundInfoFetcher(unittest.TestCase):
         self.info_fetcher._fetch_txt_info = \
             Mock(return_value={'changeset': '123456789'})
 
-        result = self.info_fetcher.find_build_info('123456789')
+        result = self.info_fetcher.find_build_info('123456789', 1)
         self.assertEqual(result.build_url,
                          'http://firefox-42.0a1.en-US.linux-x86_64.tar.bz2')
         self.assertEqual(result.changeset, '123456789')
@@ -152,7 +152,7 @@ class TestInboundInfoFetcher(unittest.TestCase):
             side_effect=fetch_build_info.TaskclusterFailure
         )
         with self.assertRaises(errors.BuildInfoNotFound):
-            self.info_fetcher.find_build_info('123456789')
+            self.info_fetcher.find_build_info('123456789', 1)
 
     def test_get_valid_build_no_artifacts(self):
         def find_task(route):
@@ -173,12 +173,12 @@ class TestInboundInfoFetcher(unittest.TestCase):
         self.info_fetcher.queue.listArtifacts = list_artifacts
 
         with self.assertRaises(errors.BuildInfoNotFound):
-            self.info_fetcher.find_build_info('123456789')
+            self.info_fetcher.find_build_info('123456789', 1)
 
     @patch('mozregression.json_pushes.JsonPushes.pushlog_for_change')
     def test_find_build_info_check_changeset_error(self, pushlog_for_change):
         pushlog_for_change.side_effect = errors.MozRegressionError
         with self.assertRaises(errors.BuildInfoNotFound):
             self.info_fetcher.find_build_info('123456789',
-                                              check_changeset=True)
+                                              push_date=None)
         pushlog_for_change.assert_called_with('123456789')

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -4,7 +4,8 @@ import re
 import pytest
 
 from mozregression.fetch_configs import (FirefoxConfig, create_config, errors,
-                                         get_build_regex, NIGHTLY_BASE_URL)
+                                         get_build_regex, NIGHTLY_BASE_URL,
+                                         TIMESTAMP_GECKO_V2)
 
 
 class TestFirefoxConfigLinux64(unittest.TestCase):
@@ -224,38 +225,49 @@ CHSET = "47856a21491834da3ab9b308145caa8ec1b98ee1"
 CHSET12 = "47856a214918"
 
 
-@pytest.mark.parametrize("app,os,bits,expected", [
+@pytest.mark.parametrize("app,os,bits,repo,push_date,expected", [
     # firefox
-    ("firefox", 'linux', 32,
+    ("firefox", 'linux', 32, None, TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.mozilla-inbound.linux' % CHSET),
-    ("firefox", 'linux', 64,
+    ("firefox", 'linux', 64, 'm-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.mozilla-inbound.linux64' % CHSET),
-    ("firefox", 'win', 32,
+    ("firefox", 'win', 32, 'm-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.mozilla-inbound.win32' % CHSET),
-    ("firefox", 'win', 64,
+    ("firefox", 'win', 64, 'm-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.mozilla-inbound.win64' % CHSET),
-    ("firefox", 'mac', 64,
+    ("firefox", 'mac', 64, 'm-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.mozilla-inbound.macosx64' % CHSET),
+    ("firefox", 'linux', 64, 'm-c', TIMESTAMP_GECKO_V2-1,
+     'buildbot.revisions.%s.mozilla-central.linux64' % CHSET),
+    ("firefox", 'linux', 64, 'm-i', TIMESTAMP_GECKO_V2,
+     'gecko.v2.mozilla-inbound.revision.%s.firefox.linux64-opt' % CHSET),
+    ("firefox", 'linux', 64, 'try', TIMESTAMP_GECKO_V2-1,
+     'gecko.v2.try.revision.%s.firefox.linux64-opt' % CHSET),
     # fennec
-    ("fennec", None, None,
+    ("fennec", None, None, None, TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.mozilla-inbound.android-api-11' % CHSET),
-    ("fennec-2.3", None, None,
+    ("fennec", None, None, None, TIMESTAMP_GECKO_V2,
+     'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-11-opt' % CHSET),
+    ("fennec-2.3", None, None, 'm-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.mozilla-inbound.android-api-9' % CHSET),
+    ("fennec-2.3", None, None, 'm-i', TIMESTAMP_GECKO_V2,
+     'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-9-opt' % CHSET),
     # b2g
-    ("b2g", 'linux', 32,
+    ("b2g", 'linux', 32, None, TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.b2g-inbound.linux_gecko' % CHSET),
-    ("b2g", 'linux', 64,
+    ("b2g", 'linux', 64, 'b-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.b2g-inbound.linux64_gecko' % CHSET),
-    ("b2g", 'win', 32,
+    ("b2g", 'win', 32, 'b-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.b2g-inbound.win32_gecko' % CHSET12),
-    ("b2g", 'win', 64,
+    ("b2g", 'win', 64, 'b-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.b2g-inbound.win64_gecko' % CHSET12),
-    ("b2g", 'mac', 64,
+    ("b2g", 'mac', 64, 'b-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.b2g-inbound.macosx64_gecko' % CHSET12),
 ])
-def test_tk_inbound_route(app, os, bits, expected):
+def test_tk_inbound_route(app, os, bits, repo, push_date, expected):
     conf = create_config(app, os, bits)
-    result = conf.tk_inbound_route(CHSET)
+    conf.set_repo(repo)
+    result = conf.tk_inbound_route(CHSET, push_date)
     assert result == expected
 
 
@@ -278,7 +290,7 @@ def test_tk_inbound_route(app, os, bits, expected):
 def test_tk_inbound_route_with_build_type(app, os, bits, build_type, expected):
     conf = create_config(app, os, bits)
     conf.set_build_type(build_type)
-    result = conf.tk_inbound_route(CHSET)
+    result = conf.tk_inbound_route(CHSET, TIMESTAMP_GECKO_V2-1)
     assert result == expected
 
 

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -331,5 +331,22 @@ def test_jsshell_build_regex(os, bits, name):
     assert re.match(conf.build_regex(), name)
 
 
+@pytest.mark.parametrize('os,bits,tc_suffix', [
+    ('linux', 32, 'linux-pgo'),
+    ('linux', 64, 'linux64-pgo'),
+    ('mac', 64, errors.MozRegressionError),
+    ('win', 32, 'win32-pgo'),
+    ('win', 64, 'win64-pgo'),
+])
+def test_set_firefox_build_type_pgo(os, bits, tc_suffix):
+    conf = create_config('firefox', os, bits)
+    if type(tc_suffix) is not str:
+        with pytest.raises(tc_suffix):
+            conf.set_build_type('pgo')
+    else:
+        conf.set_build_type('pgo')
+        assert conf.tk_inbound_route(CHSET, TIMESTAMP_GECKO_V2) \
+                   .endswith('.' + tc_suffix)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add gecko.v2 support routes, and this offer some new build types: pgo and asan for firefox/jsshell, and debug for fennec.

Because gecko.v2 routes are quite new, this patch only use them if the push date of the changeset is after september 2015.

https://bugzilla.mozilla.org/show_bug.cgi?id=1234030