### PR TITLE
Bug 1245335 - use android-api-15 for recent fennec builds

### DIFF
--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -7,7 +7,8 @@ from mock import Mock
 from mozregression.json_pushes import Push
 from mozregression.fetch_configs import (FirefoxConfig, create_config, errors,
                                          get_build_regex, ARCHIVE_BASE_URL,
-                                         TIMESTAMP_GECKO_V2)
+                                         TIMESTAMP_GECKO_V2,
+                                         TIMESTAMP_FENNEC_API_15)
 
 
 def create_push(chset, timestamp):
@@ -166,6 +167,12 @@ class TestFennecConfig(unittest.TestCase):
         regex = self.conf.get_nightly_repo_regex(datetime.date(2015,
                                                                1, 1))
         self.assertIn("mozilla-central-android-api-11", regex)
+        regex = self.conf.get_nightly_repo_regex(datetime.date(2016,
+                                                               1, 28))
+        self.assertIn("mozilla-central-android-api-11", regex)
+        regex = self.conf.get_nightly_repo_regex(datetime.date(2016,
+                                                               1, 29))
+        self.assertIn("mozilla-central-android-api-15", regex)
 
     def test_build_regex(self):
         regex = re.compile(self.conf.build_regex())
@@ -261,6 +268,8 @@ CHSET12 = "47856a214918"
      'buildbot.revisions.%s.mozilla-inbound.android-api-11' % CHSET),
     ("fennec", None, None, None, TIMESTAMP_GECKO_V2,
      'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-11-opt' % CHSET),
+    ("fennec", None, None, None, TIMESTAMP_FENNEC_API_15,
+     'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-15-opt' % CHSET),
     ("fennec-2.3", None, None, 'm-i', TIMESTAMP_GECKO_V2-1,
      'buildbot.revisions.%s.mozilla-inbound.android-api-9' % CHSET),
     ("fennec-2.3", None, None, 'm-i', TIMESTAMP_GECKO_V2,


### PR DESCRIPTION
For both archives.m.o and taskcluster, fennec route names have changed since
around 2016-01-29 - and mozregression can't find recent builds because
of that.

This patch should solve the issue by using api-15 instead of api-11
after this date.