### PR TITLE
Make the GitHub "Fork Me" ribbon http(s) agnostic

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,4 +30,4 @@
   </div>
 
 </header>
-<a class="hide-on-palm" href="{{site.github_url}}"><img style="position: absolute; top: 0; right: 0; border: 0;margin:0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
+<a class="hide-on-palm" href="{{site.github_url}}"><img style="position: absolute; top: 0; right: 0; border: 0;margin:0;" src="//s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>


### PR DESCRIPTION
Will fix a mixed-content warning when the page is viewed over https.