### PR TITLE
drop stray space before question mark

### DIFF
--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -449,7 +449,7 @@ class Configuration(object):
                     raise MozRegressionError(
                         ("Good date %s is later than bad date %s."
                          " Maybe you wanted to use the --find-fix"
-                         " flag ?") % (options.good, options.bad))
+                         " flag?") % (options.good, options.bad))
                 elif options.find_fix and \
                         to_datetime(options.good) < to_datetime(options.bad):
                     raise MozRegressionError(


### PR DESCRIPTION
If you use mozregression with a "good" date that's newer than the "bad" date, it asks you:
> Maybe you wanted to use the --find-fix flag ?

Note the awkward space character at the end of the sentence there, before the question mark.  This pull request just drops that stray space.