### PR TITLE
Use mozdevice 0.47 only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ DEPENDENCIES = [
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1212170
     'requests>=2.4.3,<3',
     'redo',
-    'mozdevice >= 0.47',
+    # require mozdevice 0.47 because 0.48 requires rooted devices
+    'mozdevice == 0.47',
     'taskcluster>=0.0.32',
     'colorama',
     'configobj',


### PR DESCRIPTION
Work around mozdevice 0.48 requiring rooted devices by using the older version. https://bugzilla.mozilla.org/show_bug.cgi?id=1245347