### PR TITLE
Allow for a bisection without a download manager

### DIFF
--- a/mozregression/bisector.py
+++ b/mozregression/bisector.py
@@ -416,7 +416,7 @@ class Bisection(object):
         found, mid_point, build_infos, persist_files = self._find_approx_build(
             mid_point, build_infos
         )
-        if not found:
+        if not found and self.download_manager:
             # else, do the download. Note that nothing will
             # be downloaded if the exact build file is already present.
             self.download_manager.focus_download(build_infos)


### PR DESCRIPTION
This allows a bisection to take place without using a download manager.
This is particularly useful bisecting builds where the data we're
interested in is already in test logs, so no binary is necessary.

My use case was to create a custom TestRunner that greps through logs looking for a specific warning. I use `mozregression.bisector.Bisector` to drive the bisection and let the TestRunner take care of downloading.

@parkouss What do you think?