### PR TITLE
Bug 1278683 - Update config and build info handling

### DIFF
--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -125,6 +125,15 @@ class InboundInfoFetcher(InfoFetcher):
                     task_id = self.index.findTask(old_route)['taskId']
                 except TaskclusterFailure:
                     err = True
+            elif 'debug' in tk_route:
+                err = False
+                try:
+                    new_route = tk_route.replace('debug', 'dbg')
+                    LOG.debug('using alternate debug route %r' % new_route)
+                    task_id = self.index.findTask(new_route)['taskId']
+                except TaskclusterFailure:
+                    err = True
+
             if err:
                 raise BuildInfoNotFound("Unable to find build info using the"
                                         " taskcluster route %r" % tk_route)

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -70,7 +70,9 @@ def get_build_regex(name, os, bits, psuffix='', with_ext=True):
             " os is reported as '%s'." % os
         )
 
-    regex = '%s%s%s' % (name, suffix, psuffix)
+    # New taskcluster builds now just name the binary archive 'target', so
+    # that is added as one possibility in the regex.
+    regex = '(target|%s%s%s)' % (name, suffix, psuffix)
     if with_ext:
         return '%s%s' % (regex, ext)
     else:

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -209,32 +209,32 @@ class TestB2GConfig(unittest.TestCase):
 class TestGetBuildUrl(unittest.TestCase):
     def test_for_linux(self):
         self.assertEqual(get_build_regex('test', 'linux', 32),
-                         r'test.*linux-i686\.tar.bz2')
+                         r'(target|test.*linux-i686)\.tar.bz2')
 
         self.assertEqual(get_build_regex('test', 'linux', 64),
-                         r'test.*linux-x86_64\.tar.bz2')
+                         r'(target|test.*linux-x86_64)\.tar.bz2')
 
         self.assertEqual(get_build_regex('test', 'linux', 64,
                                          with_ext=False),
-                         r'test.*linux-x86_64')
+                         r'(target|test.*linux-x86_64)')
 
     def test_for_win(self):
         self.assertEqual(get_build_regex('test', 'win', 32),
-                         r'test.*win32\.zip')
+                         r'(target|test.*win32)\.zip')
         self.assertEqual(get_build_regex('test', 'win', 64),
-                         r'test.*win64(-x86_64)?\.zip')
+                         r'(target|test.*win64(-x86_64)?)\.zip')
         self.assertEqual(get_build_regex('test', 'win', 64,
                                          with_ext=False),
-                         r'test.*win64(-x86_64)?')
+                         r'(target|test.*win64(-x86_64)?)')
 
     def test_for_mac(self):
         self.assertEqual(get_build_regex('test', 'mac', 32),
-                         r'test.*mac.*\.dmg')
+                         r'(target|test.*mac.*)\.dmg')
         self.assertEqual(get_build_regex('test', 'mac', 64),
-                         r'test.*mac.*\.dmg')
+                         r'(target|test.*mac.*)\.dmg')
         self.assertEqual(get_build_regex('test', 'mac', 64,
                                          with_ext=False),
-                         r'test.*mac.*')
+                         r'(target|test.*mac.*)')
 
     def test_unknown_os(self):
         with self.assertRaises(errors.MozRegressionError):


### PR DESCRIPTION
Taskcluster routes (for linux64 debug at least) have temporarily changed
from using 'debug' to 'dbg'. Eventually this behavior will revert but
for now we need to special case it.

Additionally the binary archive name for builds in taskcluster has
changed from specifying the platform and architecture to just using a
generic term, 'target', for all platforms. The build regex has been
updated to handle that behavior.