### PR TITLE
Fix bisect progress type mismatch, convert dates to datetimes

### DIFF
--- a/mozregression/bisector.py
+++ b/mozregression/bisector.py
@@ -8,6 +8,7 @@ import threading
 from mozlog import get_proxy_logger
 
 from mozregression.build_range import range_for_inbounds, range_for_nightlies
+from mozregression.dates import to_datetime
 from mozregression.errors import LauncherError, MozRegressionError, \
     GoodBadExpectationError, EmptyPushlogError
 from mozregression.history import BisectionHistory
@@ -154,13 +155,15 @@ class NightlyHandler(BisectorHandler):
     def _print_progress(self, new_data):
         next_good_date = new_data[0].build_date
         next_bad_date = new_data[-1].build_date
-        next_days_range = abs((next_bad_date - next_good_date).days)
+        next_days_range = abs((to_datetime(next_bad_date) -
+                               to_datetime(next_good_date)).days)
         LOG.info("Narrowed nightly regression window from"
                  " [%s, %s] (%d days) to [%s, %s] (%d days)"
                  " (~%d steps left)"
                  % (self.good_date,
                     self.bad_date,
-                    abs((self.bad_date - self.good_date).days),
+                    abs((to_datetime(self.bad_date) -
+                         to_datetime(self.good_date)).days),
                     next_good_date,
                     next_bad_date,
                     next_days_range,


### PR DESCRIPTION
I tried to do a bisect in mozregression recently and it failed with **TypeError: unsupported operand type(s) for -: 'datetime.date' and 'datetime.datetime'**. It traces back to [`_print_progress` in bisector](https://github.com/mozilla/mozregression/blob/1e38c1e/mozregression/bisector.py#L157):
~~~python
    def _print_progress(self, new_data):
        next_good_date = new_data[0].build_date
        next_bad_date = new_data[-1].build_date
        next_days_range = abs((next_bad_date - next_good_date).days)
~~~
~~~
next_good_date: 2016-07-30 03:02:04       <--- this is a datetime
next_bad_date:  2016-08-27                <--- this is a date
~~~
It appears that Python does not allow getting the delta of a date and a datetime. To fix this I am proposing a change that converts both to datetimes, as well as a similar fix for the self good/bad date which I had a similar problem with. Here is what it looks like with the fix:
~~~
next_good_date: 2016-07-30 03:02:04       <--- this is a datetime
next_bad_date:  2016-08-27 00:00:00       <--- this is a datetime
~~~

**I'm not proficient in python** and it may be better to handle this earlier when a build date is created. Though I did find [code in testrunner](https://github.com/mozilla/mozregression/blob/1e38c1e/mozregression/test_runner.py#L28) that checks a build date to see if it's an instance of datetime, so I figured it is expected that build date won't always be a datetime.


Here's the full trace:
~~~
  File "C:\Python27\Scripts\mozregression-script.py", line 9, in <module>
    load_entry_point('mozregression==2.3.8', 'console_scripts', 'mozregression')
()
  File "c:\python27\lib\site-packages\mozregression\main.py", line 308, in main
    sys.exit(method())
  File "c:\python27\lib\site-packages\mozregression\main.py", line 127, in bisec
t_nightlies
    result = self._do_bisect(handler, good_date, bad_date)
  File "c:\python27\lib\site-packages\mozregression\main.py", line 202, in _do_b
isect
    return self.bisector.bisect(handler, good, bad, **kwargs)
  File "c:\python27\lib\site-packages\mozregression\bisector.py", line 585, in b
isect
    return self._bisect(handler, build_range)
  File "c:\python27\lib\site-packages\mozregression\bisector.py", line 656, in _
bisect
    result = bisection.handle_verdict(index, verdict)
  File "c:\python27\lib\site-packages\mozregression\bisector.py", line 548, in h
andle_verdict
    self.handler.build_bad(mid_point, self.build_range)
  File "c:\python27\lib\site-packages\mozregression\bisector.py", line 122, in b
uild_bad
    self._print_progress(new_data)
  File "c:\python27\lib\site-packages\mozregression\bisector.py", line 157, in _
print_progress
    next_days_range = abs((next_bad_date - next_good_date).days)
TypeError: unsupported operand type(s) for -: 'datetime.date' and 'datetime.date
time'
~~~
Also I had some problems using mozregression from the virtualenv, Python kept using supporting scripts from the global install of mozregression. Where is the appropriate place to ask about that in detail?