### PR TITLE
Downgrade flake8 to version 2.5.4 and peg various python linting requirements

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -438,6 +438,7 @@ class FennecInboundConfigMixin(InboundConfigMixin):
 
 # ------------ full config implementations ------------
 
+
 REGISTRY = ClassRegistry('app_name')
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,10 @@
 coverage
 mock
-flake8
 pytest
+# peg flake8 + deps so code doesn't suddenly violate validation expectations unexpectedly
+flake8==3.0.4
+mccabe==0.5.2
+pyflakes==1.2.3
 
 # install mozregression
 -e .


### PR DESCRIPTION
Later versions seem to be detecting new "problems" which we may
want to fix at some point, but not now.