### PR TITLE
Bug 1334815 - Bisecting Fennec with taskcluster builds fails

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -528,10 +528,10 @@ class FennecConfig(CommonConfig,
     BUILD_TYPES = ('opt', 'debug')
 
     def build_regex(self):
-        return r'fennec-.*\.apk'
+        return r'(target|fennec-.*)\.apk'
 
     def build_info_regex(self):
-        return r'fennec-.*\.txt'
+        return r'(target|fennec-.*)\.txt'
 
     def available_bits(self):
         return ()


### PR DESCRIPTION
taskcluster changed artifact name so we can't match build file and download it.
I actually don't know which build info file (there're two, target.txt, target_info.txt) is correct.  please help to clarify, thank.

