### PR TITLE
Use a more neutral message when inbound bisection is finished

### DIFF
--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -161,7 +161,7 @@ class Application(object):
                                  ensure_good_and_bad=ensure_good_and_bad)
         result = self._do_bisect(handler, good_rev, bad_rev, expand=expand)
         if result == Bisection.FINISHED:
-            LOG.info("Oh noes, no (more) inbound revisions :(")
+            LOG.info("No more inbound revisions, bisection finished.")
             handler.print_range()
             if handler.good_revision == handler.bad_revision:
                 LOG.warning(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -131,7 +131,7 @@ def test_app_bisect_inbounds_finished(create_app, same_chsets):
     app = create_app(argv)
     app.bisector.bisect = Mock(return_value=Bisection.FINISHED)
     assert app.bisect_inbounds() == 0
-    assert create_app.find_in_log("Oh noes, no (more) inbound revisions :(")
+    assert create_app.find_in_log("No more inbound revisions, bisection finished.")
     if same_chsets:
         assert create_app.find_in_log("It seems that you used two changesets"
                                       " that are in in the same push.", False)


### PR DESCRIPTION
The "oh noes" message was cute, but it makes it seem as if something
went wrong during normal operation.