### PR TITLE
Change inbound progress message to talk about "builds" instead of "revisions"

### DIFF
--- a/mozregression/bisector.py
+++ b/mozregression/bisector.py
@@ -217,7 +217,7 @@ class InboundHandler(BisectorHandler):
 
     def _print_progress(self, new_data):
         LOG.info("Narrowed inbound regression window from [%s, %s]"
-                 " (%d revisions) to [%s, %s] (%d revisions)"
+                 " (%d builds) to [%s, %s] (%d builds)"
                  " (~%d steps left)"
                  % (self.build_range[0].short_changeset,
                     self.build_range[-1].short_changeset,

--- a/tests/unit/test_bisector.py
+++ b/tests/unit/test_bisector.py
@@ -184,8 +184,8 @@ class TestInboundHandler(unittest.TestCase):
         ]
 
         self.handler._print_progress(new_data)
-        self.assertIn('from [12, 12345] (4 revisions)', log[0])
-        self.assertIn('to [1234, 12345] (2 revisions)', log[0])
+        self.assertIn('from [12, 12345] (4 builds)', log[0])
+        self.assertIn('to [1234, 12345] (2 builds)', log[0])
         self.assertIn('1 steps left', log[0])
 
     @patch('mozregression.bisector.LOG')


### PR DESCRIPTION
There may be less builds than actual revisions if some of the builds were bad,
see e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1384136