### PR TITLE
Make sure long temporary path names are not shortened inside mozregression

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -15,7 +15,6 @@ from mozfile import rmtree
 from mozdevice import ADBAndroid, ADBHost, ADBError
 import mozversion
 import mozinstall
-import tempfile
 import zipfile
 import mozinfo
 import stat
@@ -25,6 +24,7 @@ from threading import Thread
 
 from mozregression.class_registry import ClassRegistry
 from mozregression.errors import LauncherNotRunnable, LauncherError
+from mozregression.tempdir import safe_mkdtemp
 
 LOG = get_proxy_logger("Test Runner")
 
@@ -181,7 +181,7 @@ class MozRunnerLauncher(Launcher):
     binary = None
 
     def _install(self, dest):
-        self.tempdir = tempfile.mkdtemp()
+        self.tempdir = safe_mkdtemp()
         try:
             self.binary = mozinstall.get_binary(
                 mozinstall.install(src=dest, dest=self.tempdir),
@@ -378,7 +378,7 @@ class JsShellLauncher(Launcher):
     temp_dir = None
 
     def _install(self, dest):
-        self.tempdir = tempfile.mkdtemp()
+        self.tempdir = safe_mkdtemp()
         try:
             with zipfile.ZipFile(dest, "r") as z:
                 z.extractall(self.tempdir)

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -11,7 +11,6 @@ import sys
 import requests
 import atexit
 import pipes
-import tempfile
 import mozfile
 import colorama
 
@@ -26,6 +25,7 @@ from mozregression.bisector import (Bisector, NightlyHandler, InboundHandler,
                                     Bisection)
 from mozregression.launchers import REGISTRY as APP_REGISTRY
 from mozregression.network import set_http_session
+from mozregression.tempdir import safe_mkdtemp
 from mozregression.test_runner import ManualTestRunner, CommandTestRunner
 from mozregression.download_manager import BuildDownloadManager
 from mozregression.persist_limit import PersistLimit
@@ -48,7 +48,7 @@ class Application(object):
         self._download_dir = options.persist
         self._rm_download_dir = False
         if not options.persist:
-            self._download_dir = tempfile.mkdtemp()
+            self._download_dir = safe_mkdtemp()
             self._rm_download_dir = True
         launcher_class = APP_REGISTRY.get(fetch_config.app_name)
         launcher_class.check_is_runnable()

--- a/mozregression/tempdir.py
+++ b/mozregression/tempdir.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import os
+import tempfile
+
+
+def safe_mkdtemp():
+    '''
+    Creates a temporary directory using mkdtemp, but makes sure that the
+    returned directory is the full path on windows (see:
+    https://bugzilla.mozilla.org/show_bug.cgi?id=1385928)
+    '''
+    tempdir = tempfile.mkdtemp()
+    if os.name == 'nt':
+        from ctypes import create_unicode_buffer, windll
+        BUFFER_SIZE = 500
+        buffer = create_unicode_buffer(BUFFER_SIZE)
+        get_long_path_name = windll.kernel32.GetLongPathNameW
+        get_long_path_name(unicode(tempdir), buffer, BUFFER_SIZE)
+        return buffer.value
+    else:
+        return tempdir


### PR DESCRIPTION
If they aren't, we have sandboxing problems: https://bugzilla.mozilla.org/show_bug.cgi?id=1385928