### PR TITLE
Handle Fennec's switch to android-api-16 builds

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -40,6 +40,12 @@ TIMESTAMP_FENNEC_API_15 = to_utc_timestamp(
     datetime.datetime(2016, 1, 29, 0, 30, 13)
 )
 
+# switch from fennec api-15 to api-16 on taskcluster
+# appeared on this date for m-c.
+TIMESTAMP_FENNEC_API_16 = to_utc_timestamp(
+    datetime.datetime(2017, 8, 29, 18, 28, 36)
+)
+
 
 def get_build_regex(name, os, bits, psuffix='', with_ext=True):
     """
@@ -295,8 +301,10 @@ class FennecNightlyConfigMixin(NightlyConfigMixin):
                 repo += "-android-api-10"
             elif date < datetime.date(2016, 1, 29):
                 repo += "-android-api-11"
-            else:
+            elif date < datetime.date(2017, 8, 30):
                 repo += "-android-api-15"
+            else:
+                repo += "-android-api-16"
         return self._get_nightly_repo_regex(date, repo)
 
 
@@ -384,9 +392,11 @@ class FennecInboundConfigMixin(InboundConfigMixin):
     def tk_inbound_route(self, push):
         if push.timestamp >= TIMESTAMP_GECKO_V2:
             tk_name = self.tk_name
-            if tk_name == 'android-api-11' and \
-               push.timestamp >= TIMESTAMP_FENNEC_API_15:
-                tk_name = 'android-api-15'
+            if tk_name == 'android-api-11':
+                if push.timestamp >= TIMESTAMP_FENNEC_API_16:
+                    tk_name = 'android-api-16'
+                elif push.timestamp >= TIMESTAMP_FENNEC_API_15:
+                    tk_name = 'android-api-15'
             return 'gecko.v2.{}.revision.{}.mobile.{}-{}'.format(
                 self.inbound_branch, push.changeset, tk_name,
                 self.build_type

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -8,7 +8,8 @@ from mozregression.json_pushes import Push
 from mozregression.fetch_configs import (FirefoxConfig, create_config, errors,
                                          get_build_regex, ARCHIVE_BASE_URL,
                                          TIMESTAMP_GECKO_V2,
-                                         TIMESTAMP_FENNEC_API_15)
+                                         TIMESTAMP_FENNEC_API_15,
+                                         TIMESTAMP_FENNEC_API_16)
 
 
 def create_push(chset, timestamp):
@@ -173,6 +174,9 @@ class TestFennecConfig(unittest.TestCase):
         regex = self.conf.get_nightly_repo_regex(datetime.date(2016,
                                                                1, 29))
         self.assertIn("mozilla-central-android-api-15", regex)
+        regex = self.conf.get_nightly_repo_regex(datetime.date(2017,
+                                                               8, 30))
+        self.assertIn("mozilla-central-android-api-16", regex)
 
     def test_build_regex(self):
         regex = re.compile(self.conf.build_regex())
@@ -261,6 +265,8 @@ CHSET12 = "47856a214918"
      'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-11-opt' % CHSET),
     ("fennec", None, None, None, TIMESTAMP_FENNEC_API_15,
      'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-15-opt' % CHSET),
+    ("fennec", None, None, None, TIMESTAMP_FENNEC_API_16,
+     'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-16-opt' % CHSET),
     ("fennec-2.3", None, None, 'm-i', TIMESTAMP_GECKO_V2 - 1,
      'buildbot.revisions.%s.mozilla-inbound.android-api-9' % CHSET),
     ("fennec-2.3", None, None, 'm-i', TIMESTAMP_GECKO_V2,


### PR DESCRIPTION
I hope I've picked the right timestamp for `TIMESTAMP_FENNEC_API_16` - I've used the date of [the first mozilla-central push](https://treeherder.mozilla.org/#/jobs?repo=mozilla-central&revision=d814f791de3bba0fce843614b41ca9696ce57b15&filter-searchStr=android%20(b)) that showed api-16 jobs on Treeherder.