### PR TITLE
Display usage of variables in --command argument

### DIFF
--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -195,9 +195,12 @@ def create_parser(defaults):
 
     parser.add_argument("-c", "--command",
                         help=("Test command to evaluate builds automatically."
-                              " A return code of 0 will evaluate build as"
-                              " good, any other value will evaluate the build"
-                              " as bad."))
+                              " A return code of 0 will evaluate the build as"
+                              " good, and any other value as bad."
+                              " Variables like {binary} can be used, which"
+                              " will be replaced with their value as retrieved"
+                              " by the actual build."
+                              ))
 
     parser.add_argument("--persist",
                         default=defaults["persist"],


### PR DESCRIPTION
This is a fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1408439.

It will help in cases like https://github.com/mozilla/geckodriver/issues/972#issuecomment-336484921 when we mixup in how the variable has to be specified.