### PR TITLE
Fix typo in message about 64-bit systems

### DIFF
--- a/mozregression/config.py
+++ b/mozregression/config.py
@@ -105,9 +105,9 @@ def _get_persist_size_limit(default):
 
 
 def _get_bits(default):
-    print("You are using a 64-bits system, so mozregression will by default"
-          " use the 64 bits build files. If you want to change that to"
-          " 32 bits by default, type 32 here.")
+    print("You are using a 64-bit system, so mozregression will by default"
+          " use the 64-bit build files. If you want to change that to"
+          " 32-bit by default, type 32 here.")
     while 1:
         value = raw_input('bits: ')
         if value in ('', '32', '64'):


### PR DESCRIPTION
Right now the message about default build type (64-bit vs. 32-bit) incorrectly refers to them as "64 bits" and "32 bits".  The correct/common adjective for these types of builds are "64-bit" vs. "32-bit" (singular bits, and with a hyphen).  See e.g. https://support.mozilla.org/en-US/kb/switch-32-bit-64-bit as one reference on this language.