### PR TITLE
Bug 1414879 - Avoid privacy notice on every launch

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -298,6 +298,8 @@ class FirefoxRegressionProfile(Profile):
         'datareporting.healthreport.uploadEnabled': False,
         'datareporting.healthreport.documentServerURI':
         'http://%(server)s/healthreport/',
+        # Don't show tab with privacy notice on every launch 
+        'datareporting.policy.dataSubmissionPolicyBypassNotification': True,
         # Don't report telemetry information
         'toolkit.telemetry.enabled': False,
     }

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -298,7 +298,7 @@ class FirefoxRegressionProfile(Profile):
         'datareporting.healthreport.uploadEnabled': False,
         'datareporting.healthreport.documentServerURI':
         'http://%(server)s/healthreport/',
-        # Don't show tab with privacy notice on every launch 
+        # Don't show tab with privacy notice on every launch
         'datareporting.policy.dataSubmissionPolicyBypassNotification': True,
         # Don't report telemetry information
         'toolkit.telemetry.enabled': False,


### PR DESCRIPTION
Should cover https://bugzilla.mozilla.org/show_bug.cgi?id=1414879
Feedback is appreciated in case something's wrong.