### PR TITLE
Handle transposed repo names in merge commit messages

### DIFF
--- a/mozregression/bisector.py
+++ b/mozregression/bisector.py
@@ -265,7 +265,7 @@ class InboundHandler(BisectorHandler):
         push = jp.push(most_recent_push.changeset, full='1')
         msg = push.changeset['desc']
         LOG.debug("Found commit message:\n%s\n" % msg)
-        branch = find_branch_in_merge_commit(msg)
+        branch = find_branch_in_merge_commit(msg, most_recent_push.repo_name)
         if not (branch and len(push.changesets) >= 2):
             # We did not find a branch, lets check the integration branches if we are bisecting m-c
             if get_name(most_recent_push.repo_name) == 'mozilla-central' and \

--- a/mozregression/branches.py
+++ b/mozregression/branches.py
@@ -86,16 +86,22 @@ get_branches = BRANCHES.get_branches
 get_category = BRANCHES.get_category
 
 
-RE_MERGE_BRANCH = re.compile(r"merge ([\w-]+) to [\w-]+.*", re.I)
+RE_MERGE_BRANCH = re.compile(r"merge ([\w-]+) to ([\w-]+).*", re.I)
 
 
-def find_branch_in_merge_commit(message):
+def find_branch_in_merge_commit(message, current_branch):
     """
     Try to extract the branch name where commits comes from in a merge commit
     message.
+
+    Some commit messages incorrectly transpose the repo names.  If the first
+    repo is the same as current_branch assume this is the case.
 
     Return None if the message does not looks like a merge commit.
     """
     match = RE_MERGE_BRANCH.match(message)
     if match:
-        return get_name(match.group(1))
+        if get_name(match.group(1)) == current_branch:
+            return get_name(match.group(2))
+        else:
+            return get_name(match.group(1))

--- a/mozregression/branches.py
+++ b/mozregression/branches.py
@@ -5,7 +5,11 @@ Access to mozilla branches information.
 import re
 from collections import defaultdict
 
+from mozlog import get_proxy_logger
+
 from mozregression.errors import MozRegressionError
+
+LOG = get_proxy_logger('Branches')
 
 
 class Branches(object):
@@ -102,6 +106,7 @@ def find_branch_in_merge_commit(message, current_branch):
     match = RE_MERGE_BRANCH.match(message)
     if match:
         if get_name(match.group(1)) == current_branch:
+            LOG.debug("Assuming transposed repos in merge commit message")
             return get_name(match.group(2))
         else:
             return get_name(match.group(1))

--- a/tests/unit/test_branches.py
+++ b/tests/unit/test_branches.py
@@ -55,15 +55,17 @@ def test_get_category(name, expected):
     assert branches.get_category(name) == expected
 
 
-@pytest.mark.parametrize('commit, branch', [
+@pytest.mark.parametrize('commit, branch, current', [
     ("Merge mozilla-central to autoland",
-     "mozilla-central"),
+     "mozilla-central", "autoland"),
+    ("Merge mozilla-central to autoland",
+     "autoland", "mozilla-central"),
     ("Merge autoland to central, a=merge",
-     "autoland"),
+     "autoland", "mozilla-central"),
     ("merge autoland to mozilla-central a=merge",
-     "autoland"),
+     "autoland", "mozilla-central"),
     ("Merge m-i to m-c, a=merge CLOSED TREE",
-     "mozilla-inbound"),
+     "mozilla-inbound", "mozilla-central"),
 ])
-def test_find_branch_in_merge_commit(commit, branch):
-    assert branches.find_branch_in_merge_commit(commit) == branch
+def test_find_branch_in_merge_commit(commit, branch, current):
+    assert branches.find_branch_in_merge_commit(commit, current) == branch


### PR DESCRIPTION
Some merge commit messages have the positions of the originating and target repos reversed.  This breaks mozregression's branch detection since it assumes the originating repo is always in the first position.  If the first repo is "mozilla-central" assume this is a transposed message and take the second repo's name.

I put the logging in a separate commit in case it wasn't wanted.

https://bugzilla.mozilla.org/show_bug.cgi?id=1450986