### PR TITLE
gui: fixup signal connection in wizards

### DIFF
--- a/gui/mozregui/wizard.py
+++ b/gui/mozregui/wizard.py
@@ -2,7 +2,7 @@ import mozinfo
 import datetime
 from PyQt4.QtGui import (QWizard, QWizardPage, QStringListModel, QMessageBox,
                          QCompleter, QApplication)
-from PyQt4.QtCore import QString, QDate, pyqtSlot as Slot, Qt
+from PyQt4.QtCore import QString, QDate, pyqtSlot as Slot, Qt, SIGNAL
 
 from ui.intro import Ui_Intro
 from ui.build_selection import Ui_BuildSelectionPage
@@ -254,7 +254,7 @@ class Wizard(QWizard):
 
         # associate current text to comboboxes fields instead of current index
         self.setDefaultProperty("QComboBox", "currentText",
-                                "currentIndexChanged")
+                                SIGNAL('currentIndexChanged(QString)'))
 
         for klass in class_pages:
             self.addPage(klass())


### PR DESCRIPTION
Fixes the following backtrace when running the bisection or single build wizards:

```
Traceback (most recent call last):
  File "/home/rm/src/mozregression/gui/mozregui/mainwindow.py", line 121, in single_run
    self._start_runner(SingleRunWizard, self.single_runner)
  File "/home/rm/src/mozregression/gui/mozregui/mainwindow.py", line 99, in _start_runner
    wizard = wizard_class(self)
  File "/home/rm/src/mozregression/gui/mozregui/wizard.py", line 309, in __init__
    parent=parent)
  File "/home/rm/src/mozregression/gui/mozregui/wizard.py", line 257, in __init__
    "currentIndexChanged")
TypeError: setDefaultProperty(self, str, str, QT_SIGNAL): argument 3 has unexpected type 'str'
```