### PR TITLE
Bug 1484607 - Use mozdevice adb's new `require_root` parameter

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -347,8 +347,7 @@ class FennecLauncher(Launcher):
         self.app_info = safe_get_version(binary=dest)
         self.package_name = self.app_info.get("package_name",
                                               "org.mozilla.fennec")
-        self.adb = ADBAndroid()
-        self.adb._require_root = False
+        self.adb = ADBAndroid(require_root=False)
         try:
             self.adb.uninstall_app(self.package_name)
         except ADBError, msg:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ DEPENDENCIES = [
     'mozversion==1.4',
     'requests[security]==2.19.1',
     'redo==1.6',
-    'mozdevice==1.0.1',
+    'mozdevice==1.1.0',
     'taskcluster==0.3.4',
     'colorama==0.3.7',
     'configobj==5.0.6',


### PR DESCRIPTION
Based on an earlier patch by bc <bob@bclary.com>