### PR TITLE
Bug 1464127: Bypass profile downgrade detection when using the same profile for bisection.

### DIFF
--- a/gui/mozregui/build_runner.py
+++ b/gui/mozregui/build_runner.py
@@ -152,6 +152,9 @@ class AbstractBuildRunner(QObject):
         launcher_kwargs['addons'] = options['addons']
         self.test_runner.launcher_kwargs = launcher_kwargs
 
+        if options.profile_persistence in ('clone-first', 'reuse') or options.profile:
+            launcher_kwargs['cmdargs'] = launcher_kwargs['cmdargs'] + ['--allow-downgrade']
+
         self.worker = self.worker_class(fetch_config, self.test_runner,
                                         self.download_manager)
         # Move self.bisector in the thread. This will

--- a/gui/mozregui/build_runner.py
+++ b/gui/mozregui/build_runner.py
@@ -152,7 +152,7 @@ class AbstractBuildRunner(QObject):
         launcher_kwargs['addons'] = options['addons']
         self.test_runner.launcher_kwargs = launcher_kwargs
 
-        if options.profile_persistence in ('clone-first', 'reuse') or options.profile:
+        if options['profile_persistence'] in ('clone-first', 'reuse') or options['profile']:
             launcher_kwargs['cmdargs'] = launcher_kwargs['cmdargs'] + ['--allow-downgrade']
 
         self.worker = self.worker_class(fetch_config, self.test_runner,

--- a/gui/mozregui/build_runner.py
+++ b/gui/mozregui/build_runner.py
@@ -153,7 +153,7 @@ class AbstractBuildRunner(QObject):
         self.test_runner.launcher_kwargs = launcher_kwargs
 
         if options['profile_persistence'] in ('clone-first', 'reuse') or options['profile']:
-            launcher_kwargs['cmdargs'] = launcher_kwargs['cmdargs'] + ['--allow-downgrade']
+            launcher_kwargs['cmdargs'] = launcher_kwargs.get('cmdargs', []) + ['--allow-downgrade']
 
         self.worker = self.worker_class(fetch_config, self.test_runner,
                                         self.download_manager)

--- a/gui/setup.cfg
+++ b/gui/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
 exclude = mozregui/ui/*.py
+max-line-length = 100

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -61,6 +61,9 @@ class Application(object):
                 preferences=options.preferences,
                 clone=options.profile_persistence == 'clone-first'
             )
+            options.cmdargs = options.cmdargs + ['--allow-downgrade']
+        elif options.profile:
+            options.cmdargs = options.cmdargs + ['--allow-downgrade']
 
     def clear(self):
         if self._build_download_manager:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -53,7 +53,7 @@ def test_app_get_manual_test_runner(create_app):
     app = create_app(['--profile=/prof'])
     assert isinstance(app.test_runner, ManualTestRunner)
     assert app.test_runner.launcher_kwargs == dict(
-        addons=[], profile='/prof', cmdargs=[], preferences=[]
+        addons=[], profile='/prof', cmdargs=['--allow-downgrade'], preferences=[]
     )
 
 


### PR DESCRIPTION
Once Bug 1455707 lands (planned for Jan 30th), running an older build on a profile is going to essentially bail out. This passes the necessary command line argument to bypass that in the case where every test run uses the same profile.

I'm afraid I haven't been able to run the GUI tests because they don't seem to work for me for some reason.