### PR TITLE
Bug 1533517 - Allow the user to specify a path for profile storage on android

### DIFF
--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -141,6 +141,16 @@ def create_parser(defaults):
                         metavar="PATH",
                         help="profile to use with nightlies.")
 
+    parser.add_argument('--adb-profile-dir',
+                        dest="adb_profile_dir",
+                        default=defaults["adb-profile-dir"],
+                        help=("Path to use on android devices for storing"
+                              " the profile. Generally you should not need"
+                              " to specify this, and an appropriate path"
+                              " will be used. Specifying this to a value,"
+                              " e.g. '/sdcard/tests' will forcibly try to create"
+                              " the profile inside that folder."))
+
     parser.add_argument('--profile-persistence',
                         choices=('clone', 'clone-first', 'reuse'),
                         default=defaults["profile-persistence"],

--- a/mozregression/config.py
+++ b/mozregression/config.py
@@ -34,6 +34,7 @@ DEFAULT_EXPAND = 20
 # default values when not defined in config file.
 # Note that this is also the list of options that can be used in config file
 DEFAULTS = {
+    'adb-profile-dir': None,
     'app': 'firefox',
     'approx-policy': 'auto',
     'archive-base-url': ARCHIVE_BASE_URL,

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -191,7 +191,8 @@ class MozRunnerLauncher(Launcher):
             rmtree(self.tempdir)
             raise
 
-    def _start(self, profile=None, addons=(), cmdargs=(), preferences=None):
+    def _start(self, profile=None, addons=(), cmdargs=(), preferences=None,
+               adb_profile_dir=None):
         profile = self._create_profile(profile=profile, addons=addons,
                                        preferences=preferences)
 
@@ -365,12 +366,15 @@ class AndroidLauncher(Launcher):
             )
         self.adb.install_app(dest)
 
-    def _start(self, profile=None, addons=(), cmdargs=(), preferences=None):
+    def _start(self, profile=None, addons=(), cmdargs=(), preferences=None,
+               adb_profile_dir=None):
         # for now we don't handle addons on the profile for fennec
         profile = self._create_profile(profile=profile,
                                        preferences=preferences)
         # send the profile on the device
-        self.remote_profile = "/".join([self.adb.test_root,
+        if not adb_profile_dir:
+            adb_profile_dir = self.adb.test_root
+        self.remote_profile = "/".join([adb_profile_dir,
                                        os.path.basename(profile.profile)])
         if self.adb.exists(self.remote_profile):
             self.adb.rm(self.remote_profile, recursive=True)

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -91,6 +91,7 @@ class Application(object):
                     profile=self._global_profile or self.options.profile,
                     cmdargs=self.options.cmdargs,
                     preferences=self.options.preferences,
+                    adb_profile_dir=self.options.adb_profile_dir,
                 ))
             else:
                 self._test_runner = CommandTestRunner(self.options.command)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -53,7 +53,8 @@ def test_app_get_manual_test_runner(create_app):
     app = create_app(['--profile=/prof'])
     assert isinstance(app.test_runner, ManualTestRunner)
     assert app.test_runner.launcher_kwargs == dict(
-        addons=[], profile='/prof', cmdargs=['--allow-downgrade'], preferences=[]
+        addons=[], profile='/prof', cmdargs=['--allow-downgrade'], preferences=[],
+        adb_profile_dir=None
     )
 
 


### PR DESCRIPTION
On some devices apparently the first-attempted path of
/storage/sdcard0/tests works to create the profile, but then the profile
is not readable from the app being tested (e.g. GVE). This patch allows
the user to override the default path to one that may work better.