### PR TITLE
Improve support for version numbers on release repos

### DIFF
--- a/gui/mozregui/ui/intro.ui
+++ b/gui/mozregui/ui/intro.ui
@@ -61,7 +61,7 @@
    <item row="3" column="1">
     <widget class="QLineEdit" name="repository">
      <property name="toolTip">
-      <string>repository like mozilla-aurora|mozilla-beta|...</string>
+      <string>repository like mozilla-inbound|mozilla-beta|...</string>
      </property>
      <property name="placeholderText">
       <string>you can choose a specific repository name here</string>

--- a/mozregression/branches.py
+++ b/mozregression/branches.py
@@ -63,7 +63,7 @@ def create_branches():
                             category='integration')
 
     # release branches
-    for name in ("comm-aurora", "comm-beta", "comm-release", "mozilla-aurora",
+    for name in ("comm-beta", "comm-release",
                  "mozilla-beta", "mozilla-release"):
         branches.set_branch(name, "releases/%s" % name)
 
@@ -73,7 +73,6 @@ def create_branches():
     for name, aliases in (
             ("mozilla-central", ("m-c", "central")),
             ("mozilla-inbound", ("m-i", "inbound", "mozilla inbound")),
-            ("mozilla-aurora", ("aurora",)),
             ("mozilla-beta", ("beta",))):
         for alias in aliases:
             branches.set_alias(alias, name)

--- a/mozregression/branches.py
+++ b/mozregression/branches.py
@@ -73,7 +73,7 @@ def create_branches():
     for name, aliases in (
             ("mozilla-central", ("m-c", "central")),
             ("mozilla-inbound", ("m-i", "inbound", "mozilla inbound")),
-            ("mozilla-beta", ("beta",))):
+            ("mozilla-beta", ("m-b", "beta"))):
         for alias in aliases:
             branches.set_alias(alias, name)
     return branches

--- a/mozregression/branches.py
+++ b/mozregression/branches.py
@@ -65,7 +65,7 @@ def create_branches():
     # release branches
     for name in ("comm-beta", "comm-release",
                  "mozilla-beta", "mozilla-release"):
-        branches.set_branch(name, "releases/%s" % name)
+        branches.set_branch(name, "releases/%s" % name, category='releases')
 
     branches.set_branch('try', 'try', category='try')
 

--- a/mozregression/branches.py
+++ b/mozregression/branches.py
@@ -73,7 +73,8 @@ def create_branches():
     for name, aliases in (
             ("mozilla-central", ("m-c", "central")),
             ("mozilla-inbound", ("m-i", "inbound", "mozilla inbound")),
-            ("mozilla-beta", ("m-b", "beta"))):
+            ("mozilla-beta", ("m-b", "beta")),
+            ("mozilla-release", ("m-r", "release"))):
         for alias in aliases:
             branches.set_alias(alias, name)
     return branches

--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -417,8 +417,12 @@ class Configuration(object):
                     self.logger.info("Using tag %s for release %s"
                                      % (new_value, value))
                     value = new_value
-                elif get_name(repo) == 'mozilla-beta':
+                elif (get_name(repo) == 'mozilla-beta' or
+                      (not repo and re.match(r'^\d+\.0b\d+$', value))):
                     new_value = tag_of_beta(value)
+                    if not repo:
+                        self.logger.info("Assuming repo mozilla-beta")
+                        self.fetch_config.set_repo('mozilla-beta')
                     self.logger.info("Using tag %s for release %s"
                                      % (new_value, value))
                     value = new_value

--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -28,7 +28,8 @@ from mozregression.fetch_configs import REGISTRY as FC_REGISTRY, create_config
 from mozregression.errors import (MozRegressionError, DateFormatError,
                                   UnavailableRelease)
 from mozregression.releases import (formatted_valid_release_dates,
-                                    date_of_release, tag_of_release)
+                                    date_of_release, tag_of_release,
+                                    tag_of_beta)
 from mozregression.log import init_logger, colorize
 
 
@@ -413,6 +414,11 @@ class Configuration(object):
                     if not repo:
                         self.logger.info("Assuming repo mozilla-release")
                         self.fetch_config.set_repo('mozilla-release')
+                    self.logger.info("Using tag %s for release %s"
+                                     % (new_value, value))
+                    value = new_value
+                elif get_name(repo) == 'mozilla-beta':
+                    new_value = tag_of_beta(value)
                     self.logger.info("Using tag %s for release %s"
                                      % (new_value, value))
                     value = new_value

--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -407,8 +407,12 @@ class Configuration(object):
         except DateFormatError:
             try:
                 repo = self.options.repo
-                if get_name(repo) == 'mozilla-release':
+                if (get_name(repo) == 'mozilla-release' or
+                        (not repo and re.match(r'^\d+\.\d\.\d$', value))):
                     new_value = tag_of_release(value)
+                    if not repo:
+                        self.logger.info("Assuming repo mozilla-release")
+                        self.fetch_config.set_repo('mozilla-release')
                     self.logger.info("Using tag %s for release %s"
                                      % (new_value, value))
                     value = new_value

--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -193,7 +193,7 @@ def create_parser(defaults):
                         help="application name. Default: %(default)s.")
 
     parser.add_argument("--repo",
-                        metavar="[mozilla-aurora|mozilla-inbound|autoland...]",
+                        metavar="[mozilla-inbound|autoland|mozilla-beta...]",
                         default=defaults["repo"],
                         help="repository name used for the bisection.")
 

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -200,7 +200,8 @@ class CommonConfig(object):
 
         Note that this method relies on the repo and build type defined.
         """
-        return (branches.get_category(self.repo) in ('integration', 'try') or
+        return (branches.get_category(self.repo) in
+                ('integration', 'try', 'releases') or
                 # we can find the asan builds (firefox and jsshell) in
                 # archives.m.o
                 self.build_type not in ('opt', 'asan', 'shippable'))

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -310,7 +310,7 @@ class FennecNightlyConfigMixin(NightlyConfigMixin):
 
     def get_nightly_repo_regex(self, date):
         repo = self.get_nightly_repo(date)
-        if repo in ('mozilla-central', 'mozilla-aurora'):
+        if repo in ('mozilla-central',):
             if date < datetime.date(2014, 12, 6):
                 repo += "-android"
             elif date < datetime.date(2014, 12, 13):

--- a/mozregression/releases.py
+++ b/mozregression/releases.py
@@ -125,6 +125,8 @@ def tag_of_beta(release):
     """
     if re.match(r'^\d+\.0b\d+$', release):
         return 'FIREFOX_%s_RELEASE' % release.replace('.', '_')
+    elif re.match(r'^\d+(\.0)?$', release):
+        return 'FIREFOX_RELEASE_%s_BASE' % release.replace('.0', '')
     else:
         raise UnavailableRelease(release)
 

--- a/mozregression/releases.py
+++ b/mozregression/releases.py
@@ -106,6 +106,18 @@ def date_of_release(release):
         raise UnavailableRelease(release)
 
 
+def tag_of_release(release):
+    """
+    Provide the mercurial tag of a release, suitable for use in place of a hash
+    """
+    if re.match(r'^\d+$', release):
+        release += '.0'
+    if re.match(r'^\d+\.\d(\.\d)?$', release):
+        return 'FIREFOX_%s_RELEASE' % release.replace('.', '_')
+    else:
+        raise UnavailableRelease(release)
+
+
 def formatted_valid_release_dates():
     """
     Returns a formatted string (ready to be printed) representing

--- a/mozregression/releases.py
+++ b/mozregression/releases.py
@@ -118,6 +118,17 @@ def tag_of_release(release):
         raise UnavailableRelease(release)
 
 
+def tag_of_beta(release):
+    """
+    Provide the mercurial tag of a beta release, suitable for use in place of a
+    hash
+    """
+    if re.match(r'^\d+\.0b\d+$', release):
+        return 'FIREFOX_%s_RELEASE' % release.replace('.', '_')
+    else:
+        raise UnavailableRelease(release)
+
+
 def formatted_valid_release_dates():
     """
     Returns a formatted string (ready to be printed) representing

--- a/tests/unit/test_branches.py
+++ b/tests/unit/test_branches.py
@@ -18,8 +18,8 @@ def test_branch_name(branch, alias):
      "https://hg.mozilla.org/mozilla-central"),
     ("m-i",
      "https://hg.mozilla.org/integration/mozilla-inbound"),
-    ("mozilla-aurora",
-     "https://hg.mozilla.org/releases/mozilla-aurora")
+    ("mozilla-beta",
+     "https://hg.mozilla.org/releases/mozilla-beta")
 ])
 def test_get_urls(branch, url):
     assert branches.get_url(branch) == url

--- a/tests/unit/test_branches.py
+++ b/tests/unit/test_branches.py
@@ -48,6 +48,8 @@ def test_get_url_unknown_branch():
     ('mozilla-central', 'default'),
     ('autoland', 'integration'),
     ('m-i', 'integration'),
+    ('release', 'releases'),
+    ('mozilla-beta', 'releases'),
     ('', None),
     (None, None)
 ])

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -231,6 +231,7 @@ def test_launch(args, action, value):
 @pytest.mark.parametrize('args,repo,value', [
     (['--launch=60.0', '--repo=m-r'], 'mozilla-release', 'FIREFOX_60_0_RELEASE'),
     (['--launch=61', '--repo=m-r'], 'mozilla-release', 'FIREFOX_61_0_RELEASE'),
+    (['--launch=62.0.1'], 'mozilla-release', 'FIREFOX_62_0_1_RELEASE'),
 ])
 def test_versions(args, repo, value):
     config = do_cli(*args)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -234,6 +234,7 @@ def test_launch(args, action, value):
     (['--launch=62.0.1'], 'mozilla-release', 'FIREFOX_62_0_1_RELEASE'),
     (['--launch=63.0b4', '--repo=m-b'], 'mozilla-beta', 'FIREFOX_63_0b4_RELEASE'),
     (['--launch=64', '--repo=m-b'], 'mozilla-beta', 'FIREFOX_RELEASE_64_BASE'),
+    (['--launch=65.0b11'], 'mozilla-beta', 'FIREFOX_65_0b11_RELEASE'),
 ])
 def test_versions(args, repo, value):
     config = do_cli(*args)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -228,6 +228,16 @@ def test_launch(args, action, value):
     assert config.options.launch == value
 
 
+@pytest.mark.parametrize('args,repo,value', [
+    (['--launch=60.0', '--repo=m-r'], 'mozilla-release', 'FIREFOX_60_0_RELEASE'),
+    (['--launch=61', '--repo=m-r'], 'mozilla-release', 'FIREFOX_61_0_RELEASE'),
+])
+def test_versions(args, repo, value):
+    config = do_cli(*args)
+    assert config.fetch_config.repo == repo
+    assert config.options.launch == value
+
+
 def test_bad_date_later_than_good():
     with pytest.raises(errors.MozRegressionError) as exc:
         do_cli('--good=2015-01-01', '--bad=2015-01-10', '--find-fix')

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -233,6 +233,7 @@ def test_launch(args, action, value):
     (['--launch=61', '--repo=m-r'], 'mozilla-release', 'FIREFOX_61_0_RELEASE'),
     (['--launch=62.0.1'], 'mozilla-release', 'FIREFOX_62_0_1_RELEASE'),
     (['--launch=63.0b4', '--repo=m-b'], 'mozilla-beta', 'FIREFOX_63_0b4_RELEASE'),
+    (['--launch=64', '--repo=m-b'], 'mozilla-beta', 'FIREFOX_RELEASE_64_BASE'),
 ])
 def test_versions(args, repo, value):
     config = do_cli(*args)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -232,6 +232,7 @@ def test_launch(args, action, value):
     (['--launch=60.0', '--repo=m-r'], 'mozilla-release', 'FIREFOX_60_0_RELEASE'),
     (['--launch=61', '--repo=m-r'], 'mozilla-release', 'FIREFOX_61_0_RELEASE'),
     (['--launch=62.0.1'], 'mozilla-release', 'FIREFOX_62_0_1_RELEASE'),
+    (['--launch=63.0b4', '--repo=m-b'], 'mozilla-beta', 'FIREFOX_63_0b4_RELEASE'),
 ])
 def test_versions(args, repo, value):
     config = do_cli(*args)

--- a/tests/unit/test_releases.py
+++ b/tests/unit/test_releases.py
@@ -2,7 +2,7 @@ import unittest
 
 from mozregression import errors
 from mozregression.releases import (releases, formatted_valid_release_dates,
-                                    date_of_release)
+                                    date_of_release, tag_of_release)
 
 
 class TestRelease(unittest.TestCase):
@@ -38,3 +38,19 @@ class TestRelease(unittest.TestCase):
             date_of_release(441)
         with self.assertRaises(errors.UnavailableRelease):
             date_of_release('ew21rtw112')
+
+    def test_valid_release_tags(self):
+        tag = tag_of_release('57.0')
+        self.assertEquals(tag, "FIREFOX_57_0_RELEASE")
+        tag = tag_of_release('60')
+        self.assertEquals(tag, "FIREFOX_60_0_RELEASE")
+        tag = tag_of_release('65.0.1')
+        self.assertEquals(tag, "FIREFOX_65_0_1_RELEASE")
+
+    def test_invalid_release_tags(self):
+        with self.assertRaises(errors.UnavailableRelease):
+            tag_of_release('55.0.1.1')
+        with self.assertRaises(errors.UnavailableRelease):
+            tag_of_release('57.0b4')
+        with self.assertRaises(errors.UnavailableRelease):
+            tag_of_release('abc')

--- a/tests/unit/test_releases.py
+++ b/tests/unit/test_releases.py
@@ -61,6 +61,10 @@ class TestRelease(unittest.TestCase):
         self.assertEquals(tag, "FIREFOX_57_0b9_RELEASE")
         tag = tag_of_beta('60.0b12')
         self.assertEquals(tag, "FIREFOX_60_0b12_RELEASE")
+        tag = tag_of_beta('65')
+        self.assertEquals(tag, "FIREFOX_RELEASE_65_BASE")
+        tag = tag_of_beta('66.0')
+        self.assertEquals(tag, "FIREFOX_RELEASE_66_BASE")
 
     def test_invalid_beta_tags(self):
         with self.assertRaises(errors.UnavailableRelease):

--- a/tests/unit/test_releases.py
+++ b/tests/unit/test_releases.py
@@ -2,7 +2,8 @@ import unittest
 
 from mozregression import errors
 from mozregression.releases import (releases, formatted_valid_release_dates,
-                                    date_of_release, tag_of_release)
+                                    date_of_release, tag_of_release,
+                                    tag_of_beta)
 
 
 class TestRelease(unittest.TestCase):
@@ -54,3 +55,15 @@ class TestRelease(unittest.TestCase):
             tag_of_release('57.0b4')
         with self.assertRaises(errors.UnavailableRelease):
             tag_of_release('abc')
+
+    def test_valid_beta_tags(self):
+        tag = tag_of_beta('57.0b9')
+        self.assertEquals(tag, "FIREFOX_57_0b9_RELEASE")
+        tag = tag_of_beta('60.0b12')
+        self.assertEquals(tag, "FIREFOX_60_0b12_RELEASE")
+
+    def test_invalid_beta_tags(self):
+        with self.assertRaises(errors.UnavailableRelease):
+            tag_of_beta('57.0.1')
+        with self.assertRaises(errors.UnavailableRelease):
+            tag_of_beta('xyz')


### PR DESCRIPTION
This should help with a number of ergonomic defects around the use of version numbers as build identifiers, and fixes a few different bugs: [bug 1308031](https://bugzilla.mozilla.org/show_bug.cgi?id=1308031), [bug 1494051](https://bugzilla.mozilla.org/show_bug.cgi?id=1494051), and [bug 1425164](https://bugzilla.mozilla.org/show_bug.cgi?id=1425164).