### PR TITLE
Correct error in aarch64 code in available_build_types

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -159,11 +159,13 @@ class CommonConfig(object):
         for available in self.BUILD_TYPES:
             match = re.match("(.+)\[(.+)\]", available)
             if match:
-                os = ('win64-aarch64' if self.os == 'win' and
-                      self.processor == 'aarch64' else self.os)
+                suffix = ('-aarch64' if self.processor == 'aarch64' and
+                          self.bits == 64 else '')
                 available = match.group(1)
                 platforms = match.group(2)
-                if '{}{}'.format(os, self.bits) not in platforms.split(','):
+                if '{}{}{}'.format(
+                    self.os, self.bits, suffix
+                ) not in platforms.split(','):
                     available = None
             if available:
                 res.append(available)

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -283,6 +283,27 @@ class TestFallbacksConfig(TestFirefoxConfigLinux64):
         )
 
 
+class TestAarch64AvailableBuildTypes(unittest.TestCase):
+    app_name = 'firefox'
+    os = 'win'
+    bits = 64
+    processor = 'aarch64'
+
+    def setUp(self):
+        self.conf = create_config(self.app_name, self.os, self.bits,
+                                  self.processor)
+        self.conf.BUILD_TYPES = (
+            'excluded[win64]', 'included[win64-aarch64]', 'default'
+        )
+
+    def test_aarch64_build_types(self):
+        build_types = self.conf.available_build_types()
+        assert len(build_types) == 2
+        assert 'default' in build_types
+        assert 'included' in build_types
+        assert 'excluded' not in build_types
+
+
 CHSET = "47856a21491834da3ab9b308145caa8ec1b98ee1"
 CHSET12 = "47856a214918"
 


### PR DESCRIPTION
The previous code was incorrectly checking build_types for a `win64-aarch6464`
platform, which obviously doesn't exist.  Fortunately it doesn't matter at the
moment since win64-aarch64 isn't specified for any of the limited build types.

While this could have been fixed by just trimming the 64 off the end of the
substituted `os` string value (and switching the os check for the bits check),
switching to an explicit suffix should hopefully make it clearer what is
happening.