### PR TITLE
Add comm-central to branches

### DIFF
--- a/mozregression/branches.py
+++ b/mozregression/branches.py
@@ -56,6 +56,7 @@ def create_branches():
     branches = Branches()
 
     branches.set_branch("mozilla-central", "mozilla-central")
+    branches.set_branch("comm-central", "comm-central")
 
     # integration branches
     for name in ("autoland", "mozilla-inbound"):


### PR DESCRIPTION
Sorry, but I couldn't build this myself on my windows machine, but I believe this single line change is enough to add comm-central repository to the list of branches. It is also maybe time to remove mozilla-aurora and comm-aurora from the release branches, because they are out of use since May 2017.