### PR TITLE
Bug 1422606 - Add support for opening app to a specific URL from GUI

### DIFF
--- a/gui/mozregui/build_runner.py
+++ b/gui/mozregui/build_runner.py
@@ -155,6 +155,12 @@ class AbstractBuildRunner(QObject):
         if options['profile_persistence'] in ('clone-first', 'reuse') or options['profile']:
             launcher_kwargs['cmdargs'] = launcher_kwargs.get('cmdargs', []) + ['--allow-downgrade']
 
+        # Thunderbird will fail to start if passed an URL arg
+        if 'url' in options and fetch_config.app_name != 'thunderbird':
+            launcher_kwargs['cmdargs'] = (
+                launcher_kwargs.get('cmdargs', []) + [options['url']]
+            )
+
         self.worker = self.worker_class(fetch_config, self.test_runner,
                                         self.download_manager)
         # Move self.bisector in the thread. This will

--- a/gui/mozregui/ui/intro.ui
+++ b/gui/mozregui/ui/intro.ui
@@ -68,6 +68,26 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="url_label">
+     <property name="toolTip">
+      <string>enter a URL to pass to the app</string>
+     </property>
+     <property name="text">
+      <string>URL:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="url">
+     <property name="toolTip">
+      <string>URL such as example.org, https://mozilla.org, about:logo</string>
+     </property>
+     <property name="placeholderText">
+      <string>Open the app to a specific URL</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/gui/mozregui/wizard.py
+++ b/gui/mozregui/wizard.py
@@ -58,7 +58,7 @@ class IntroPage(WizardPage):
     SUBTITLE = ("Please choose an application and other options to specify"
                 " what you want to test.")
     FIELDS = {'application': 'app_combo', "repository": "repository",
-              'bits': 'bits_combo', "build_type": "build_type"}
+              'bits': 'bits_combo', "build_type": "build_type", "url": "url"}
 
     def __init__(self):
         WizardPage.__init__(self)
@@ -128,6 +128,14 @@ class IntroPage(WizardPage):
         else:
             self.ui.bits_combo.show()
             self.ui.label_4.show()
+
+        # URL doesn't make sense for Thunderbird
+        if app_name == 'thunderbird':
+            self.ui.url.hide()
+            self.ui.url_label.hide()
+        else:
+            self.ui.url.show()
+            self.ui.url_label.show()
 
     def validatePage(self):
         app_name = self.fetch_config.app_name


### PR DESCRIPTION
Useful when needing to run a test with a specific site

I punted on generic arg in GUI support, since just a URL should cover most use cases.