### PR TITLE
Bug 1508061 - Move find fix checkbox above the build selection fields

### DIFF
--- a/gui/mozregui/ui/build_selection.ui
+++ b/gui/mozregui/ui/build_selection.ui
@@ -15,26 +15,6 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Last known good build:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="BuildSelection" name="start" native="true"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>First known bad build:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="BuildSelection" name="end" native="true"/>
-   </item>
-   <item row="2" column="0">
     <widget class="QLabel" name="label_4">
      <property name="toolTip">
       <string>Search a fix instead of a regression</string>
@@ -44,12 +24,32 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="0" column="1">
     <widget class="QCheckBox" name="find_fix">
      <property name="text">
       <string>(Search for a bug fix instead of a regression)</string>
      </property>
     </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Last known good build:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="BuildSelection" name="start" native="true"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>First known bad build:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="BuildSelection" name="end" native="true"/>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Since the checkbox changes the labels and meaning of the fields it is confusing
to have it come after, since it could invalidate data the user already entered.