### PR TITLE
py3: Switch from .next() method to next() function in tk_inbound_rout…

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -343,7 +343,7 @@ class InboundConfigMixin:
         """
         Returns the first taskcluster route for a specific changeset
         """
-        return self.tk_inbound_routes(push).next()
+        return next(self.tk_inbound_routes(push))
 
     @abstractmethod
     def tk_inbound_routes(self, push):


### PR DESCRIPTION
…e for compat