### PR TITLE
Don't expose fallback routes in warning-level logs.

### DIFF
--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -122,7 +122,8 @@ class InboundInfoFetcher(InfoFetcher):
                 raise stored_failure
         except TaskclusterFailure:
             raise BuildInfoNotFound("Unable to find build info using the"
-                                    " taskcluster route %r" % tk_route)
+                                    " taskcluster route %r" %
+                                    self.fetch_config.tk_inbound_route(push))
 
         # find a completed run for that task
         run_id, build_date = None, None


### PR DESCRIPTION
Previously when mozregression failed to find any builds for a revision (because
of build failures, or in this case builds not yet being complete) after doing
route fallback it would print a log message about failing to find build info at
the final route it tried (pgo).
This caused actual confusion for a user who thought GUI had ignored the choice
of shippable. Log the original requested route instead.