### PR TITLE
Bug 1567259 - Bail out of check_expand if not enough valid builds.

### DIFF
--- a/mozregression/build_range.py
+++ b/mozregression/build_range.py
@@ -179,6 +179,10 @@ class BuildRange(object):
         self._fetch((0, -1))
         self.filter_invalid_builds()
 
+        if len(self) < 2:
+            # we need at least two valid builds to expand the range
+            return
+
         def _search(br, index, rng):
             while len(br):
                 if interrupt and interrupt():

--- a/tests/unit/test_build_range.py
+++ b/tests/unit/test_build_range.py
@@ -111,6 +111,8 @@ def range_after(fb, expand):
 @pytest.mark.parametrize('size_expand,initial,fail_in,expected,error', [
     # short range
     (10, range(1), [], range(1), None),
+    # empty range after removing invalids
+    (10, range(2), [0, 1], [], None),
     # lower limit missing
     (10, range(10), [0], [-1] + range(1, 10), None),
     # higher limit missing


### PR DESCRIPTION
BuildRange's check_expand bails if it doesn't have enough builds to start with,
but it then filters out any invalid builds, which can reduce the amount below
the required threshold (2), and doesn't then check again. At that point
continuing will throw IndexErrors since it assumes there will be items at
indexes 0 and -1.