### PR TITLE
Fixes for py3 unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ matrix:
   include:
     - env: python2-linux
       os: linux
+      virtualenv:
+        system_site_packages: true
+      language: python
       python: '2.7'
       script:
+        - pip install -r requirements-gui-dev.txt
         - coverage run setup.py test && mv .coverage .coverage.core
         - coverage run gui/build.py test && mv .coverage .coverage.gui
         - coverage combine
@@ -11,22 +15,28 @@ matrix:
         - python gui/build.py bundle
     - env: python3-linux
       os: linux
+      language: python
       python: '3.5'
       script:
+        - pip install -r requirements-dev.txt
         - coverage run setup.py test && mv .coverage .coverage.core
         - coverage combine
         - pip install coveralls; coveralls
     - env: python2-linters
       os: linux
+      language: python
       python: '2.7'
       script:
+        - pip install flake8
         - flake8 mozregression tests setup.py
         - flake8 gui/mozregui gui/build.py gui/tests
     - env: python3-linters
       os: linux
+      language: python
       python: '3.5'
       script:
-        - python3 -m compileall -q tests mozregression
+        - pip install flake8
+        - python -m compileall -q tests mozregression
         - flake8 mozregression tests setup.py
 
 install:
@@ -50,9 +60,6 @@ install:
           sudo install_name_tool -id $PWD/QtGui.so QtGui.so;
           cd $MOZPATH;
       fi
-    - virtualenv --system-site-packages venv
-    - source venv/bin/activate
-    - pip install -r requirements-gui-dev.txt
 
 deploy:
   - provider: releases

--- a/gui/tests/test_build_runner.py
+++ b/gui/tests/test_build_runner.py
@@ -59,12 +59,12 @@ class TestGuiBuildDownloadManager(unittest.TestCase):
             self.dl_manager.focus_download(build_info)
 
         # build_path is defined
-        self.assertEquals(build_info.build_file,
+        self.assertEqual(build_info.build_file,
                           self.dl_manager.get_dest('foo'))
 
         # signals have been emitted
-        self.assertEquals(self.signals['download_started'].call_count, 1)
-        self.assertEquals(self.signals['download_finished'].call_count, 1)
+        self.assertEqual(self.signals['download_started'].call_count, 1)
+        self.assertEqual(self.signals['download_finished'].call_count, 1)
         self.assertTrue(self.signals['download_progress'].call_count >= 2)
 
         # well, file has been downloaded finally
@@ -85,24 +85,24 @@ class TestGuiTestRunner(unittest.TestCase):
         create_launcher.return_value = launcher
 
         # nothing called yet
-        self.assertEquals(self.evaluate_started.call_count, 0)
-        self.assertEquals(self.evaluate_finished.call_count, 0)
+        self.assertEqual(self.evaluate_started.call_count, 0)
+        self.assertEqual(self.evaluate_finished.call_count, 0)
 
         self.test_runner.evaluate(Mock())
 
         # now evaluate_started has been called
-        self.assertEquals(self.evaluate_started.call_count, 1)
-        self.assertEquals(self.evaluate_finished.call_count, 0)
+        self.assertEqual(self.evaluate_started.call_count, 1)
+        self.assertEqual(self.evaluate_finished.call_count, 0)
         # launcher is defined
-        self.assertEquals(self.test_runner.launcher, launcher)
+        self.assertEqual(self.test_runner.launcher, launcher)
 
         self.test_runner.finish('g')
 
         # now evaluate_finished has been called
-        self.assertEquals(self.evaluate_started.call_count, 1)
-        self.assertEquals(self.evaluate_finished.call_count, 1)
+        self.assertEqual(self.evaluate_started.call_count, 1)
+        self.assertEqual(self.evaluate_finished.call_count, 1)
         # verdict is defined, launcher is None
-        self.assertEquals(self.test_runner.verdict, 'g')
+        self.assertEqual(self.test_runner.verdict, 'g')
 
 
 def test_abstract_build_runner(qtbot):

--- a/gui/tests/test_build_runner.py
+++ b/gui/tests/test_build_runner.py
@@ -60,7 +60,7 @@ class TestGuiBuildDownloadManager(unittest.TestCase):
 
         # build_path is defined
         self.assertEqual(build_info.build_file,
-                          self.dl_manager.get_dest('foo'))
+                         self.dl_manager.get_dest('foo'))
 
         # signals have been emitted
         self.assertEqual(self.signals['download_started'].call_count, 1)

--- a/mozregression/approx_persist.py
+++ b/mozregression/approx_persist.py
@@ -35,7 +35,7 @@ class ApproxPersistChooser(object):
         iterate over the possible file name regexes that can match
         an approx build, without the exact filename
         """
-        around = len(build_range) / self.one_every
+        around = len(build_range) // self.one_every
         index = build_range.index(build_info)
 
         def date_or_chset(next_index):

--- a/mozregression/bugzilla.py
+++ b/mozregression/bugzilla.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import re
 from mozregression.json_pushes import JsonPushes
 
-RE_BUG_ID = re.compile('bug\s+(\d+)', re.I)
+RE_BUG_ID = re.compile(r'bug\s+(\d+)', re.I)
 
 
 def find_bugids_in_push(branch, changeset):

--- a/mozregression/build_info.py
+++ b/mozregression/build_info.py
@@ -147,7 +147,7 @@ class BuildInfo(object):
         the fetch_config.build_regex() value. For example, it can return:
 
         '2015-01-11--mozilla-central--firefox.*linux-x86_64\.tar.bz2$'
-        """
+        """ # noqa
         if self.build_type == 'nightly':
             if isinstance(data, datetime.datetime):
                 prefix = data.strftime("%Y-%m-%d-%H-%M-%S")

--- a/mozregression/download_manager.py
+++ b/mozregression/download_manager.py
@@ -163,6 +163,7 @@ class Download(object):
                 # https://bugzilla.mozilla.org/show_bug.cgi?id=1185756
                 with tempfile.NamedTemporaryFile(
                         delete=False,
+                        mode='w',
                         suffix='.tmp',
                         dir=os.path.dirname(dest)) as temp:
                     for chunk in response.iter_content(chunk_size):

--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -59,7 +59,7 @@ class InfoFetcher(object):
             # the txt file could be in an old format:
             # DATE CHANGESET
             # we can try to extract that to get the changeset at least.
-            matched = re.match('^\d+ (\w+)$', response.text.strip())
+            matched = re.match(r'^\d+ (\w+)$', response.text.strip())
             if matched:
                 data['changeset'] = matched.group(1)
         return data

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -159,7 +159,7 @@ class CommonConfig(object):
     def available_build_types(self):
         res = []
         for available in self.BUILD_TYPES:
-            match = re.match("(.+)\[(.+)\]", available)
+            match = re.match(r"(.+)\[(.+)\]", available)
             if match:
                 suffix = ('-aarch64' if self.processor == 'aarch64' and
                           self.bits == 64 else '')

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -14,7 +14,7 @@ import time
 from mozlog.structured import get_default_logger, get_proxy_logger
 from mozprofile import ThunderbirdProfile, Profile
 from mozrunner import Runner
-from mozfile import rmtree
+from mozfile import remove
 from mozdevice import ADBAndroid, ADBHost, ADBError
 import mozversion
 import mozinstall
@@ -191,7 +191,7 @@ class MozRunnerLauncher(Launcher):
                 self.app_name
             )
         except Exception:
-            rmtree(self.tempdir)
+            remove(self.tempdir)
             raise
 
     def _disableUpdateByPolicy(self):
@@ -283,7 +283,7 @@ class MozRunnerLauncher(Launcher):
         finally:
             # always remove tempdir
             if self.tempdir is not None:
-                rmtree(self.tempdir)
+                remove(self.tempdir)
 
     def get_app_info(self):
         return safe_get_version(binary=self.binary)
@@ -487,7 +487,7 @@ class JsShellLauncher(Launcher):
             # set the file executable
             os.chmod(self.binary, os.stat(self.binary).st_mode | stat.S_IEXEC)
         except Exception:
-            rmtree(self.tempdir)
+            remove(self.tempdir)
             raise
 
     def _start(self, **kwargs):
@@ -511,4 +511,4 @@ class JsShellLauncher(Launcher):
         finally:
             # always remove tempdir
             if self.tempdir is not None:
-                rmtree(self.tempdir)
+                remove(self.tempdir)

--- a/mozregression/releases.py
+++ b/mozregression/releases.py
@@ -75,13 +75,13 @@ def releases():
     }
 
     def filter_tags(tag_node):
-        match = re.match("^FIREFOX_NIGHTLY_(\d+)_END$", tag_node["tag"])
+        match = re.match(r"^FIREFOX_NIGHTLY_(\d+)_END$", tag_node["tag"])
         return int(match.group(1)) > 56 if match else False
 
     def map_tags(tag_node):
         release = {}
         merge_date = date.fromtimestamp(tag_node["date"][0] + tag_node["date"][1])
-        ver_match = re.search("_(\d+)_", tag_node["tag"])
+        ver_match = re.search(r"_(\d+)_", tag_node["tag"])
         release[int(ver_match.group(1))] = merge_date.isoformat()
         return release
 

--- a/mozregression/test_runner.py
+++ b/mozregression/test_runner.py
@@ -198,10 +198,7 @@ class CommandTestRunner(TestRunner):
 
             env = dict(os.environ)
             for k, v in six.iteritems(variables):
-                if type(v) == six.text_type:
-                    v = v.encode('ascii', errors='ignore')
-                else:
-                    env['MOZREGRESSION_' + k.upper()] = str(v)
+                env['MOZREGRESSION_' + k.upper()] = str(v)
             try:
                 command = self.command.format(**variables)
             except KeyError as exc:

--- a/tests/unit/test_approx_persist.py
+++ b/tests/unit/test_approx_persist.py
@@ -55,7 +55,7 @@ def test_approx_index(bdata, mid, around, fnames, result):
     # this is always a firefox 64 linux build info
     binfo = create_build_info(build_info.InboundBuildInfo)
     brange = create_build_range(bdata)
-    brange.index = lambda _: mid or len(bdata) / 2
+    brange.index = lambda _: mid or len(bdata) // 2
     approx = approx_persist.ApproxPersistChooser(around)
 
     assert approx.index(brange, binfo, fnames) == result

--- a/tests/unit/test_bisector.py
+++ b/tests/unit/test_bisector.py
@@ -26,6 +26,10 @@ class TestBisectorHandler(unittest.TestCase):
             {'build_url': 'http://build_url_0', 'repository': 'my'}
         ])
 
+        # shim for py2.7
+        if not hasattr(self, 'assertRaisesRegex'):
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
     def test_initialize(self):
         self.handler.set_build_range([
             Mock(changeset='1', repo_url='my'),
@@ -232,6 +236,10 @@ class TestBisector(unittest.TestCase):
                                  dl_in_background=False)
         self.bisector.download_background = False
 
+        # shim for py2.7
+        if not hasattr(self, 'assertRaisesRegex'):
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
     def test__bisect_no_data(self):
         build_range = MyBuildData()
         result = self.bisector._bisect(self.handler, build_range)
@@ -266,11 +274,11 @@ class TestBisector(unittest.TestCase):
 
     def test_ensure_good_bad_invalid(self):
         self.handler.ensure_good_and_bad = True
-        with self.assertRaisesRegexp(MozRegressionError,
+        with self.assertRaisesRegex(MozRegressionError,
                                      "expected to be good"):
             self.do__bisect(MyBuildData([1, 2, 3, 4, 5]), ['b'])
 
-        with self.assertRaisesRegexp(MozRegressionError,
+        with self.assertRaisesRegex(MozRegressionError,
                                      "expected to be bad"):
             self.do__bisect(MyBuildData([1, 2, 3, 4, 5]), ['g', 'g'])
 

--- a/tests/unit/test_bisector.py
+++ b/tests/unit/test_bisector.py
@@ -26,10 +26,6 @@ class TestBisectorHandler(unittest.TestCase):
             {'build_url': 'http://build_url_0', 'repository': 'my'}
         ])
 
-        # shim for py2.7
-        if not hasattr(self, 'assertRaisesRegex'):
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
     def test_initialize(self):
         self.handler.set_build_range([
             Mock(changeset='1', repo_url='my'),

--- a/tests/unit/test_bisector.py
+++ b/tests/unit/test_bisector.py
@@ -275,11 +275,11 @@ class TestBisector(unittest.TestCase):
     def test_ensure_good_bad_invalid(self):
         self.handler.ensure_good_and_bad = True
         with self.assertRaisesRegex(MozRegressionError,
-                                     "expected to be good"):
+                                    "expected to be good"):
             self.do__bisect(MyBuildData([1, 2, 3, 4, 5]), ['b'])
 
         with self.assertRaisesRegex(MozRegressionError,
-                                     "expected to be bad"):
+                                    "expected to be bad"):
             self.do__bisect(MyBuildData([1, 2, 3, 4, 5]), ['g', 'g'])
 
     def test_ensure_good_bad(self):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,11 +21,11 @@ import six
 class TestParseDate(unittest.TestCase):
     def test_valid_date(self):
         date = cli.parse_date("2014-07-05")
-        self.assertEquals(date, datetime.date(2014, 7, 5))
+        self.assertEqual(date, datetime.date(2014, 7, 5))
 
     def test_parse_buildid(self):
         date = cli.parse_date("20151103030248")
-        self.assertEquals(date, datetime.datetime(2015, 11, 3, 3, 2, 48))
+        self.assertEqual(date, datetime.datetime(2015, 11, 3, 3, 2, 48))
 
     def test_invalid_date(self):
         self.assertRaises(errors.DateFormatError, cli.parse_date,
@@ -70,7 +70,7 @@ class TestPreferences(unittest.TestCase):
         prefs_args = ["browser.tabs.remote.autostart"]
 
         prefs = cli.preferences(None, prefs_args, None)
-        self.assertEquals(len(prefs), 0)
+        self.assertEqual(len(prefs), 0)
 
 
 class TestCli(unittest.TestCase):

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -48,8 +48,8 @@ class TestDownload(unittest.TestCase):
         self.assertFalse(self.dl.is_canceled())
         self.assertFalse(self.dl.is_running())
         self.assertIsNone(self.dl.error())
-        self.assertEquals(self.dl.get_url(), 'http://url')
-        self.assertEquals(self.dl.get_dest(), self.tempfile)
+        self.assertEqual(self.dl.get_url(), 'http://url')
+        self.assertEqual(self.dl.get_dest(), self.tempfile)
 
     def create_response(self, data, wait=0):
         mock_response(self.session_response, data, wait)
@@ -68,7 +68,7 @@ class TestDownload(unittest.TestCase):
         self.finished.assert_called_with(self.dl)
         # file has been downloaded
         with open(self.tempfile) as f:
-            self.assertEquals(f.read(), '1234' * 4)
+            self.assertEqual(f.read(), '1234' * 4)
 
     def test_download_cancel(self):
         self.create_response('1234' * 1000, wait=0.01)
@@ -104,7 +104,7 @@ class TestDownload(unittest.TestCase):
         self.dl.start()
         self.dl.wait()
 
-        self.assertEquals(data, [
+        self.assertEqual(data, [
             (self.dl, 0, 16),
             (self.dl, 4, 16),
             (self.dl, 8, 16),
@@ -113,7 +113,7 @@ class TestDownload(unittest.TestCase):
         ])
         # file has been downloaded
         with open(self.tempfile) as f:
-            self.assertEquals(f.read(), '1234' * 4)
+            self.assertEqual(f.read(), '1234' * 4)
         # finished callback was called
         self.finished.assert_called_with(self.dl)
 
@@ -125,7 +125,7 @@ class TestDownload(unittest.TestCase):
         with self.assertRaises(IOError):
             self.dl.wait()
 
-        self.assertEquals(self.dl.error()[0], IOError)
+        self.assertEqual(self.dl.error()[0], IOError)
         # finished callback was called
         self.finished.assert_called_with(self.dl)
 
@@ -185,12 +185,12 @@ class TestDownloadManager(unittest.TestCase):
         # with the same fname, no new download is started. The same instance
         # is returned since the download is running.
         dl2 = self.do_download('http://bar', 'foo', 'hello2' * 4, wait=0.02)
-        self.assertEquals(dl1, dl2)
+        self.assertEqual(dl1, dl2)
 
         # starting a download with another fname will trigger a new download
         dl3 = self.do_download('http://bar', 'foo2', 'hello you' * 4)
         self.assertIsInstance(dl3, download_manager.Download)
-        self.assertNotEquals(dl3, dl1)
+        self.assertNotEqual(dl3, dl1)
 
         # let's wait for the downloads to finish
         dl3.wait()
@@ -204,11 +204,11 @@ class TestDownloadManager(unittest.TestCase):
         def content(fname):
             with open(os.path.join(self.tempdir, fname)) as f:
                 return f.read()
-        self.assertEquals(content('foo'), 'hello' * 4)
-        self.assertEquals(content('foo2'), 'hello you' * 4)
+        self.assertEqual(content('foo'), 'hello' * 4)
+        self.assertEqual(content('foo2'), 'hello you' * 4)
 
         # download instances are removed from the manager (internal test)
-        self.assertEquals(self.dl_manager._downloads, {})
+        self.assertEqual(self.dl_manager._downloads, {})
 
     def test_cancel(self):
         dl1 = self.do_download('http://foo', 'foo', 'foo' * 50000, wait=0.02)
@@ -241,13 +241,13 @@ class TestDownloadManager(unittest.TestCase):
         dl2.wait(raise_if_error=False)
 
         # at the end, only dl3 has been downloaded
-        self.assertEquals(os.listdir(self.tempdir), ["foobar"])
+        self.assertEqual(os.listdir(self.tempdir), ["foobar"])
 
         with open(os.path.join(self.tempdir, 'foobar')) as f:
-            self.assertEquals(f.read(), 'foobar' * 4)
+            self.assertEqual(f.read(), 'foobar' * 4)
 
         # download instances are removed from the manager (internal test)
-        self.assertEquals(self.dl_manager._downloads, {})
+        self.assertEqual(self.dl_manager._downloads, {})
 
 
 class TestDownloadProgress(unittest.TestCase):
@@ -271,8 +271,8 @@ class TestBuildDownloadManager(unittest.TestCase):
             'build_url': 'http://some/thing',
             'persist_filename': '2015-01-03--my-repo--thing'
         }))
-        self.assertEquals(url, 'http://some/thing')
-        self.assertEquals(fname, '2015-01-03--my-repo--thing')
+        self.assertEqual(url, 'http://some/thing')
+        self.assertEqual(fname, '2015-01-03--my-repo--thing')
 
     @patch("mozregression.download_manager.BuildDownloadManager."
            "_extract_download_info")
@@ -286,7 +286,7 @@ class TestBuildDownloadManager(unittest.TestCase):
         extract.assert_called_with({'build': 'info'})
         download.assert_called_with('http://foo/bar', 'myfile')
         self.assertIn('myfile', self.dl_manager._downloads_bg)
-        self.assertEquals(result, ANY)
+        self.assertEqual(result, ANY)
 
     @patch('mozregression.download_manager.LOG')
     @patch("mozregression.download_manager.BuildDownloadManager."
@@ -317,13 +317,13 @@ class TestBuildDownloadManager(unittest.TestCase):
         self.assertFalse(curent_download.is_canceled())
         curent_download.wait.assert_called_with()
 
-        self.assertEquals(other_download.is_canceled(), other_canceled)
+        self.assertEqual(other_download.is_canceled(), other_canceled)
 
         log.info.assert_called_with(
             "Downloading build from: http://foo/bar")
 
-        self.assertEquals(result, current_dest)
-        self.assertEquals(result, build_info.build_file)
+        self.assertEqual(result, current_dest)
+        self.assertEqual(result, build_info.build_file)
 
     def test_focus_download(self):
         self._test_focus_download(True)
@@ -350,5 +350,5 @@ class TestBuildDownloadManager(unittest.TestCase):
         log.info.assert_called_with(
             "Using local file: %s (downloaded in background)" % dest_file)
 
-        self.assertEquals(result, dest_file)
-        self.assertEquals(result, build_info.build_file)
+        self.assertEqual(result, dest_file)
+        self.assertEqual(result, build_info.build_file)

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import re
 import pytest
 from mozregression import log
-from StringIO import StringIO
+from six import StringIO
 from colorama import Fore, Style
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -280,7 +280,7 @@ class TestMain(unittest.TestCase):
         # bisect_nightlies has been called
         self.app.bisect_nightlies.assert_called_with()
         # we exited with the return value of bisect_nightlies
-        self.assertEquals(exitcode, 0)
+        self.assertEqual(exitcode, 0)
 
     def test_bisect_inbounds(self):
         self.app.bisect_inbounds.return_value = 0

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -20,7 +20,7 @@ class TestUrlLinks(unittest.TestCase):
         </body>
         """)
         self.assertEqual(network.url_links(''),
-                          ['thing/', 'thing2/'])
+                         ['thing/', 'thing2/'])
 
     @patch('requests.get')
     def test_url_with_links_regex(self, get):
@@ -43,7 +43,7 @@ class TestUrlLinks(unittest.TestCase):
         </body>
         """)
         self.assertEqual(network.url_links(''),
-                          ['thing/', 'thing2'])
+                         ['thing/', 'thing2'])
 
 
 def test_set_http_session():

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -9,7 +9,7 @@ class TestUrlLinks(unittest.TestCase):
     @patch('requests.get')
     def test_url_no_links(self, get):
         get.return_value = Mock(text='')
-        self.assertEquals(network.url_links(''), [])
+        self.assertEqual(network.url_links(''), [])
 
     @patch('requests.get')
     def test_url_with_links(self, get):
@@ -19,7 +19,7 @@ class TestUrlLinks(unittest.TestCase):
         <a href="thing2/">thing2</a>
         </body>
         """)
-        self.assertEquals(network.url_links(''),
+        self.assertEqual(network.url_links(''),
                           ['thing/', 'thing2/'])
 
     @patch('requests.get')
@@ -30,7 +30,7 @@ class TestUrlLinks(unittest.TestCase):
         <a href="thing2/">thing2</a>
         </body>
         """)
-        self.assertEquals(
+        self.assertEqual(
             network.url_links('', regex="thing2.*"),
             ['thing2/'])
 
@@ -42,7 +42,7 @@ class TestUrlLinks(unittest.TestCase):
         <a href="/useless/thing2">thing2</a>
         </body>
         """)
-        self.assertEquals(network.url_links(''),
+        self.assertEqual(network.url_links(''),
                           ['thing/', 'thing2'])
 
 

--- a/tests/unit/test_persist_limit.py
+++ b/tests/unit/test_persist_limit.py
@@ -17,7 +17,7 @@ class TempCreator(object):
 
     def create_file(self, name, size, delay):
         fname = os.path.join(self.tempdir, name)
-        with open(fname, 'wb') as f:
+        with open(fname, 'w') as f:
             f.write('a' * size)
         # equivalent to touch, but we apply a delay for the test
         atime = time.time() + delay

--- a/tests/unit/test_releases.py
+++ b/tests/unit/test_releases.py
@@ -26,7 +26,7 @@ class TestRelease(unittest.TestCase):
             if "Valid releases: " in line:
                 continue
 
-            fields = line.translate(None, " ").split(":")
+            fields = line.replace(" ", "").split(":")
             version = int(fields[0])
             date = fields[1]
 

--- a/tests/unit/test_releases.py
+++ b/tests/unit/test_releases.py
@@ -10,13 +10,13 @@ from mozregression.releases import (releases, formatted_valid_release_dates,
 class TestRelease(unittest.TestCase):
     def test_valid_release_to_date(self):
         date = date_of_release(8)
-        self.assertEquals(date, "2011-08-16")
+        self.assertEqual(date, "2011-08-16")
         date = date_of_release(15)
-        self.assertEquals(date, "2012-06-05")
+        self.assertEqual(date, "2012-06-05")
         date = date_of_release(34)
-        self.assertEquals(date, "2014-09-02")
+        self.assertEqual(date, "2014-09-02")
         date = date_of_release('33')
-        self.assertEquals(date, "2014-07-21")
+        self.assertEqual(date, "2014-07-21")
 
     def test_valid_formatted_release_dates(self):
         formatted_output = formatted_valid_release_dates()
@@ -31,7 +31,7 @@ class TestRelease(unittest.TestCase):
             date = fields[1]
 
             self.assertTrue(version in firefox_releases)
-            self.assertEquals(date, firefox_releases[version])
+            self.assertEqual(date, firefox_releases[version])
 
     def test_invalid_release_to_date(self):
         with self.assertRaises(errors.UnavailableRelease):
@@ -43,11 +43,11 @@ class TestRelease(unittest.TestCase):
 
     def test_valid_release_tags(self):
         tag = tag_of_release('57.0')
-        self.assertEquals(tag, "FIREFOX_57_0_RELEASE")
+        self.assertEqual(tag, "FIREFOX_57_0_RELEASE")
         tag = tag_of_release('60')
-        self.assertEquals(tag, "FIREFOX_60_0_RELEASE")
+        self.assertEqual(tag, "FIREFOX_60_0_RELEASE")
         tag = tag_of_release('65.0.1')
-        self.assertEquals(tag, "FIREFOX_65_0_1_RELEASE")
+        self.assertEqual(tag, "FIREFOX_65_0_1_RELEASE")
 
     def test_invalid_release_tags(self):
         with self.assertRaises(errors.UnavailableRelease):
@@ -59,13 +59,13 @@ class TestRelease(unittest.TestCase):
 
     def test_valid_beta_tags(self):
         tag = tag_of_beta('57.0b9')
-        self.assertEquals(tag, "FIREFOX_57_0b9_RELEASE")
+        self.assertEqual(tag, "FIREFOX_57_0b9_RELEASE")
         tag = tag_of_beta('60.0b12')
-        self.assertEquals(tag, "FIREFOX_60_0b12_RELEASE")
+        self.assertEqual(tag, "FIREFOX_60_0b12_RELEASE")
         tag = tag_of_beta('65')
-        self.assertEquals(tag, "FIREFOX_RELEASE_65_BASE")
+        self.assertEqual(tag, "FIREFOX_RELEASE_65_BASE")
         tag = tag_of_beta('66.0')
-        self.assertEquals(tag, "FIREFOX_RELEASE_66_BASE")
+        self.assertEqual(tag, "FIREFOX_RELEASE_66_BASE")
 
     def test_invalid_beta_tags(self):
         with self.assertRaises(errors.UnavailableRelease):

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -163,6 +163,9 @@ class TestCommandTestRunner(unittest.TestCase):
         self.launcher = Mock()
         del self.launcher.binary  # block the auto attr binary on the mock
 
+        if not hasattr(self, 'assertRaisesRegex'):
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
     def test_create(self):
         self.assertEqual(self.runner.command, 'my command')
 
@@ -215,28 +218,28 @@ class TestCommandTestRunner(unittest.TestCase):
 
     def test_command_placeholder_error(self):
         self.runner.command = 'run {app_nam} "1"'
-        self.assertRaisesRegexp(errors.TestCommandError,
+        self.assertRaisesRegex(errors.TestCommandError,
                                 'formatting',
                                 self.evaluate)
 
     def test_command_empty_error(self):
         # in case the command line is empty,
         # subprocess.call will raise IndexError
-        self.assertRaisesRegexp(errors.TestCommandError,
+        self.assertRaisesRegex(errors.TestCommandError,
                                 'Empty', self.evaluate,
                                 subprocess_call_effect=IndexError)
 
     def test_command_missing_error(self):
         # in case the command is missing or not executable,
         # subprocess.call will raise IOError
-        self.assertRaisesRegexp(errors.TestCommandError,
+        self.assertRaisesRegex(errors.TestCommandError,
                                 'not found', self.evaluate,
                                 subprocess_call_effect=OSError)
 
     def test_run_once(self):
         self.runner.evaluate = Mock(return_value='g')
         build_info = Mock()
-        self.assertEquals(self.runner.run_once(build_info), 0)
+        self.assertEqual(self.runner.run_once(build_info), 0)
         self.runner.evaluate.assert_called_once_with(build_info)
 
 

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -219,22 +219,22 @@ class TestCommandTestRunner(unittest.TestCase):
     def test_command_placeholder_error(self):
         self.runner.command = 'run {app_nam} "1"'
         self.assertRaisesRegex(errors.TestCommandError,
-                                'formatting',
-                                self.evaluate)
+                               'formatting',
+                               self.evaluate)
 
     def test_command_empty_error(self):
         # in case the command line is empty,
         # subprocess.call will raise IndexError
         self.assertRaisesRegex(errors.TestCommandError,
-                                'Empty', self.evaluate,
-                                subprocess_call_effect=IndexError)
+                               'Empty', self.evaluate,
+                               subprocess_call_effect=IndexError)
 
     def test_command_missing_error(self):
         # in case the command is missing or not executable,
         # subprocess.call will raise IOError
         self.assertRaisesRegex(errors.TestCommandError,
-                                'not found', self.evaluate,
-                                subprocess_call_effect=OSError)
+                               'not found', self.evaluate,
+                               subprocess_call_effect=OSError)
 
     def test_run_once(self):
         self.runner.evaluate = Mock(return_value='g')
@@ -257,7 +257,7 @@ from .test_build_range import range_creator  # noqa
     # small range, no input
     (list(range(3)), Exception('input called, it should not happen'), None, 1)
 ])
-def test_index_to_try_after_skip(mocker, range_creator, brange,
+def test_index_to_try_after_skip(mocker, range_creator, brange, # noqa
                                  input, allowed_range, result):
     build_range = range_creator.create(brange)
     mocked_input = mocker.patch("mozregression.test_runner.input")


### PR DESCRIPTION
There are still 2 failing unit tests

test_pushes_within_changes - AssertionError @ retry_get.assert_has_calls():
subsequent chained functions are called but for some reason not recognised

TestCommandTestRunner.test_env_vars:
some env vars are missing in passed_env