### PR TITLE
Revert "Bug 1464127: Make FirefoxLauncher always add --allow-downgrad…

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -331,13 +331,6 @@ class FirefoxLauncher(MozRunnerLauncher):
         super(FirefoxLauncher, self)._install(dest)
         self._disableUpdateByPolicy()
 
-    def _start(
-        self, profile=None, addons=(), cmdargs=(), preferences=None, adb_profile_dir=None,
-    ):
-        super(FirefoxLauncher, self)._start(
-            profile, addons, ["--allow-downgrade"] + cmdargs, preferences, adb_profile_dir,
-        )
-
 
 class ThunderbirdRegressionProfile(ThunderbirdProfile):
     """


### PR DESCRIPTION
…e to cmdargs (#534)"

For breaking URL arguments on older builds, and not fixing what it was trying
to.

This reverts commit 5b237ea1315df3d27891e71a5338d4cfb31851c1.