### PR TITLE
Bug 1404520 - Raise a helpful error when missing required build info

### DIFF
--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -188,6 +188,13 @@ class NightlyInfoFetcher(InfoFetcher):
                     and self.build_info_regex.match(link):
                 data['build_txt_url'] = url + link
         if data:
+            # Check that we found all required data. The URL in build_url is
+            # required. build_txt_url is optional.
+            if 'build_url' not in data:
+                raise BuildInfoNotFound(
+                    "Failed to find a build file in directory {} that "
+                    "matches regex '{}'".format(url, self.build_regex.pattern))
+
             with self._fetch_lock:
                 lst.append((index, data))
 


### PR DESCRIPTION
The NightlyInfoFetcher._fetch_build_info_from_url() method constructs
a dict with at least one key, "build_url", that is passed back
to the caller. However it was possible under specific circumstances to
build a dict where the "build_url" key was missing, causing later parts
of the program to fail.

This code adds a check for the "build_url" key and raises a helpful
error if the key is missing.