### PR TITLE
Bug 1404520 - Fix the Linux ASAN build file regex

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -483,7 +483,7 @@ class FirefoxConfig(CommonConfig,
     def build_regex(self):
         return get_build_regex(
             self.app_name, self.os, self.bits, self.processor,
-            psuffix='-asan' if 'asan' in self.build_type else ''
+            psuffix='-asan-reporter' if 'asan' in self.build_type else ''
         ) + '$'
 
 


### PR DESCRIPTION
Fix the regex used to find Linux ASAN build files.