### PR TITLE
Pin travis to using trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty  # xenial seems to have some weird ssl error with python2
 matrix:
   include:
     - env: python2-linux


### PR DESCRIPTION
The new xenial distribution seems to be having some problems with openssl + python2