### PR TITLE
Bump pinned version of requests to 2.22

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ mozprofile==2.2.0
 mozrunner==7.4.0
 mozversion==2.1.0
 redo==2.0.2
-requests[security]==2.21.0
+requests[security]==2.22.0
 taskcluster==6.0.0
 
 # for some reason we need to specify a specific version of six


### PR DESCRIPTION
Implicitly bumps the used version of urllib to 1.25+.