### PR TITLE
Bug 1589881 - Don't fail if a pushlog URL 404's

### DIFF
--- a/tests/unit/test_json_pushes.py
+++ b/tests/unit/test_json_pushes.py
@@ -35,7 +35,7 @@ def test_push(mocker):
 
 def test_push_404_error(mocker):
     retry_get = mocker.patch('mozregression.json_pushes.retry_get')
-    response = Mock(status_code=404)
+    response = Mock(status_code=404, json=Mock(return_value={"error": "unknown revision"}))
     retry_get.return_value = response
 
     jpushes = JsonPushes()


### PR DESCRIPTION
Currently if a push doesn't exist in a repo we look for it in, the 404 error results in a `MozRegressionError` exception, which is fatal. That means we're failing out if a push doesn't exist in any one of the repos we search, even if it does exist in another (for example, an autoland push that's been merged to central, but not yet back to inbound). So, change that exception to an `EmptyPushlogError`, which isn't fatal.

I'd expect this to be a pretty common problem now that merges to mozilla-inbound have been slowed down and commit access to it is being sharply limited.