### PR TITLE
Bug 1596201 - Try both taskcluster archives when dowloading builds from autoland or inbound

### DIFF
--- a/mozregression/config.py
+++ b/mozregression/config.py
@@ -12,6 +12,7 @@ import os
 import mozinfo
 
 from configobj import ConfigObj, ParseError
+from datetime import datetime
 
 from mozregression.log import colorize
 from mozregression.errors import MozRegressionError
@@ -28,6 +29,9 @@ TC_CREDENTIALS_FNAME = os.path.expanduser(
     os.path.join("~", ".mozilla", "mozregression",
                  "taskcluster-credentials.json")
 )
+OLD_TC_ROOT_URL = "https://taskcluster.net"
+TC_ROOT_URL = "https://firefox-ci-tc.services.mozilla.com"
+TC_ROOT_URL_MIGRATION_FLAG_DATE = datetime.strptime('2019-11-09', '%Y-%M-%d')
 ARCHIVE_BASE_URL = "https://archive.mozilla.org/pub"
 # when a bisection range needs to be expanded, the following value is used to
 # specify how many builds we try (if 20, we will try 20 before the lower limit,

--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -16,6 +16,8 @@ from mozlog import get_proxy_logger
 from threading import Thread, Lock
 from requests import HTTPError
 
+from mozregression.config import (OLD_TC_ROOT_URL, TC_ROOT_URL,
+                                  TC_ROOT_URL_MIGRATION_FLAG_DATE)
 from mozregression.network import url_links, retry_get
 from mozregression.errors import BuildInfoNotFound, MozRegressionError
 from mozregression.build_info import NightlyBuildInfo, InboundBuildInfo
@@ -80,9 +82,6 @@ class InfoFetcher(object):
 class InboundInfoFetcher(InfoFetcher):
     def __init__(self, fetch_config):
         InfoFetcher.__init__(self, fetch_config)
-        options = fetch_config.tk_options()
-        self.index = taskcluster.Index(options)
-        self.queue = taskcluster.Queue(options)
         self.jpushes = JsonPushes(branch=fetch_config.inbound_branch)
 
     def find_build_info(self, push):
@@ -104,20 +103,36 @@ class InboundInfoFetcher(InfoFetcher):
 
         changeset = push.changeset
 
-        tk_routes = self.fetch_config.tk_inbound_routes(push)
         try:
+            # taskcluster builds have two possible root urls: we switched
+            # from taskcluster.net -> firefox-ci-tc.services.mozilla.com
+            # around November 9. to make things faster, we'll iterate through
+            # them based on the one that most likely applies to this push
+            possible_tc_root_urls = [TC_ROOT_URL, OLD_TC_ROOT_URL]
+            if push.utc_date < TC_ROOT_URL_MIGRATION_FLAG_DATE:
+                possible_tc_root_urls.reverse()
+
             task_id = None
-            stored_failure = None
-            for tk_route in tk_routes:
-                LOG.debug('using taskcluster route %r' % tk_route)
-                try:
-                    task_id = self.index.findTask(tk_route)['taskId']
-                except TaskclusterFailure as ex:
-                    LOG.debug('nothing found via route %r' % tk_route)
-                    stored_failure = ex
-                    continue
-                if task_id:
-                    status = self.queue.status(task_id)['status']
+            status = None
+            for tc_root_url in possible_tc_root_urls:
+                LOG.debug('using taskcluster root url %s' % tc_root_url)
+                options = self.fetch_config.tk_options(tc_root_url)
+                tc_index = taskcluster.Index(options)
+                tc_queue = taskcluster.Queue(options)
+                tk_routes = self.fetch_config.tk_inbound_routes(push)
+                stored_failure = None
+                for tk_route in tk_routes:
+                    LOG.debug('using taskcluster route %r' % tk_route)
+                    try:
+                        task_id = tc_index.findTask(tk_route)['taskId']
+                    except TaskclusterFailure as ex:
+                        LOG.debug('nothing found via route %r' % tk_route)
+                        stored_failure = ex
+                        continue
+                    if task_id:
+                        status = tc_queue.status(task_id)['status']
+                        break
+                if status:
                     break
             if not task_id:
                 raise stored_failure
@@ -138,16 +153,16 @@ class InboundInfoFetcher(InfoFetcher):
         if run_id is None:
             raise BuildInfoNotFound("Unable to find completed runs for task %s"
                                     % task_id)
-        artifacts = self.queue.listArtifacts(task_id, run_id)['artifacts']
+        artifacts = tc_queue.listArtifacts(task_id, run_id)['artifacts']
 
         # look over the artifacts of that run
         build_url = None
         for a in artifacts:
             name = os.path.basename(a['name'])
             if self.build_regex.search(name):
-                meth = self.queue.buildUrl
+                meth = tc_queue.buildUrl
                 if self.fetch_config.tk_needs_auth():
-                    meth = self.queue.buildSignedUrl
+                    meth = tc_queue.buildSignedUrl
                 build_url = meth('getArtifact', task_id, run_id, a['name'])
                 break
         if build_url is None:

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -373,12 +373,12 @@ class InboundConfigMixin(six.with_metaclass(ABCMeta)):
         """
         self._tk_credentials = creds
 
-    def tk_options(self):
+    def tk_options(self, root_url):
         """
         Returns the takcluster options, including the credentials required to
         download private artifacts.
         """
-        tk_options = {'rootUrl': 'https://taskcluster.net'}
+        tk_options = {'rootUrl': root_url}
         if self.tk_needs_auth():
             tk_options.update({'credentials': self._tk_credentials})
         return tk_options

--- a/tests/unit/test_fetch_build_info.py
+++ b/tests/unit/test_fetch_build_info.py
@@ -137,33 +137,25 @@ class TestInboundInfoFetcher(unittest.TestCase):
                                                    'x86_64')
         self.info_fetcher = fetch_build_info.InboundInfoFetcher(fetch_config)
 
-    def test_find_build_info(self):
-        # patch task cluster related stuff
-
-        def find_task(route):
-            return {'taskId': 'task1'}
-
-        def status(task_id):
-            return {"status": {"runs": [{
+    @patch('taskcluster.Index')
+    @patch('taskcluster.Queue')
+    def test_find_build_info(self, Queue, Index):
+        Index.return_value.findTask.return_value = {'taskId': 'task1'}
+        Queue.return_value.status.return_value = {
+            "status": {"runs": [{
                 "state": "completed",
                 "runId": 0,
                 "resolved": '2015-06-01T22:13:02.115Z'
-            }]}}
-
-        def list_artifacts(taskid, run_id):
-            return {"artifacts": [
+            }]}
+        }
+        Queue.return_value.listArtifacts.return_value = {
+            "artifacts": [
                 # return two valid artifact names
                 {'name': 'firefox-42.0a1.en-US.linux-x86_64.tar.bz2'},
                 {'name': 'firefox-42.0a1.en-US.linux-x86_64.txt'},
-            ]}
-
-        def build_url(method_name, task_id, run_id, name):
-            return 'http://' + name
-
-        self.info_fetcher.index.findTask = find_task
-        self.info_fetcher.queue.status = status
-        self.info_fetcher.queue.listArtifacts = list_artifacts
-        self.info_fetcher.queue.buildUrl = build_url
+            ]
+        }
+        Queue.return_value.buildUrl.return_value = 'http://firefox-42.0a1.en-US.linux-x86_64.tar.bz2'
         self.info_fetcher._fetch_txt_info = \
             Mock(return_value={'changeset': '123456789'})
 
@@ -174,15 +166,18 @@ class TestInboundInfoFetcher(unittest.TestCase):
         self.assertEqual(result.changeset, '123456789')
         self.assertEqual(result.build_type, "inbound")
 
-    def test_find_build_info_no_task(self):
-        self.info_fetcher.index.findTask = Mock(
+    @patch('taskcluster.Index')
+    def test_find_build_info_no_task(self, Index):
+        Index.findTask = Mock(
             side_effect=fetch_build_info.TaskclusterFailure
         )
         with self.assertRaises(errors.BuildInfoNotFound):
             self.info_fetcher.find_build_info(
                 create_push('123456789', 1))
 
-    def test_get_valid_build_no_artifacts(self):
+    @patch('taskcluster.Index')
+    @patch('taskcluster.Queue')
+    def test_get_valid_build_no_artifacts(self, Queue, Index):
         def find_task(route):
             return {'taskId': 'task1'}
 
@@ -196,9 +191,9 @@ class TestInboundInfoFetcher(unittest.TestCase):
         def list_artifacts(taskid, run_id):
             return {"artifacts": []}
 
-        self.info_fetcher.index.findTask = find_task
-        self.info_fetcher.queue.status = status
-        self.info_fetcher.queue.listArtifacts = list_artifacts
+        Index.findTask = find_task
+        Queue.status = status
+        Queue.listArtifacts = list_artifacts
 
         with self.assertRaises(errors.BuildInfoNotFound):
             self.info_fetcher.find_build_info(

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -3,7 +3,6 @@ import unittest
 import datetime
 import re
 import pytest
-from mock import Mock
 
 from mozregression.dates import to_utc_timestamp
 from mozregression.json_pushes import Push
@@ -19,7 +18,10 @@ TIMESTAMP_TEST = to_utc_timestamp(
 
 
 def create_push(chset, timestamp):
-    return Mock(changeset=chset, timestamp=timestamp, spec=Push)
+    return Push(1, {
+        'changesets': [chset],
+        'date': timestamp
+    })
 
 
 class TestFirefoxConfigLinux64(unittest.TestCase):


### PR DESCRIPTION
I have tested this in the following ways:

* tried to run a newer build on autoland, verified it downloads from firefox-ci-tc.services.mozilla.com: mozregression -d --launch 5d471a86dc2963fadc67d4d37e03e8674289dbec --repo autoland
* tried to run an older build on autoland, verified it downloads from taskcluster.net: mozregression -d --launch 6a21e61770a8668cddce4825f9199270c5de35fb --repo autoland
