### PR TITLE
Bug 1606902 - Set default integration branch to autoland

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -332,7 +332,7 @@ class InboundConfigMixin(six.with_metaclass(ABCMeta)):
     """
     Define the inbound-related required configuration.
     """
-    default_inbound_branch = 'mozilla-inbound'
+    default_inbound_branch = 'autoland'
     _tk_credentials = None
 
     @property

--- a/mozregression/json_pushes.py
+++ b/mozregression/json_pushes.py
@@ -53,7 +53,7 @@ class JsonPushes(object):
     """
     Find pushlog Push objects from a mozilla hg json-pushes api.
     """
-    def __init__(self, branch='mozilla-inbound'):
+    def __init__(self, branch='autoland'):
         self.branch = branch
         self.repo_url = branches.get_url(branch)
 

--- a/tests/unit/test_approx_persist.py
+++ b/tests/unit/test_approx_persist.py
@@ -17,7 +17,7 @@ def create_build_range(values):
 
 
 def build_firefox_name(chset):
-    return ('%s-shippable--mozilla-inbound--firefox-38.0a1.en-US.linux-x86_64.tar.bz2'
+    return ('%s-shippable--autoland--firefox-38.0a1.en-US.linux-x86_64.tar.bz2'
             % chset)
 
 

--- a/tests/unit/test_build_info.py
+++ b/tests/unit/test_build_info.py
@@ -31,7 +31,7 @@ def read_only(klass):
         defaults.extend([('repo_name', 'mozilla-central'),
                          ('build_type', 'nightly')])
     else:
-        defaults.extend([('repo_name', 'mozilla-inbound'),
+        defaults.extend([('repo_name', 'autoland'),
                          ('build_type', 'inbound')])
     return [(klass, attr, value) for attr, value in defaults]
 
@@ -107,7 +107,7 @@ def test_to_dict(klass):
     # same but for inbound
     (build_info.InboundBuildInfo,
      {},
-     '12ab12ab12ab-shippable--mozilla-inbound--url'),
+     '12ab12ab12ab-shippable--autoland--url'),
 ])
 def test_persist_filename(klass, extra, result):
     persist_part = extra.pop('persist_part', None)

--- a/tests/unit/test_build_range.py
+++ b/tests/unit/test_build_range.py
@@ -188,7 +188,7 @@ def test_range_for_inbounds(mocker):
 
     b_range = build_range.range_for_inbounds(fetch_config, 'a', 'e')
 
-    jpush_class.assert_called_once_with(branch='mozilla-inbound')
+    jpush_class.assert_called_once_with(branch='autoland')
     jpush.pushes_within_changes.assert_called_once_with('a', 'e')
     assert isinstance(b_range, build_range.BuildRange)
     assert len(b_range) == 3

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -279,10 +279,10 @@ class TestFallbacksConfig(TestFirefoxConfigLinux64):
         ))
         assert len(routes) == 3
         assert routes[0] == (
-            'gecko.v2.mozilla-inbound.revision.1a.firefox.linux64-opt'
+            'gecko.v2.autoland.revision.1a.firefox.linux64-opt'
         )
         assert routes[2] == (
-            'gecko.v2.mozilla-inbound.revision.1a.firefox.linux64-fallback'
+            'gecko.v2.autoland.revision.1a.firefox.linux64-fallback'
         )
 
 
@@ -325,11 +325,11 @@ CHSET12 = "47856a214918"
      'gecko.v2.try.shippable.revision.%s.firefox.linux64-opt' % CHSET),
     # fennec
     ("fennec", None, None, None, None, TIMESTAMP_FENNEC_API_15 - 1,
-     'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-11-opt' % CHSET),
+     'gecko.v2.autoland.revision.%s.mobile.android-api-11-opt' % CHSET),
     ("fennec", None, None, None, None, TIMESTAMP_FENNEC_API_15,
-     'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-15-opt' % CHSET),
+     'gecko.v2.autoland.revision.%s.mobile.android-api-15-opt' % CHSET),
     ("fennec", None, None, None, None, TIMESTAMP_FENNEC_API_16,
-     'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-16-opt' % CHSET),
+     'gecko.v2.autoland.revision.%s.mobile.android-api-16-opt' % CHSET),
     ("fennec-2.3", None, None, None, 'm-i', TIMESTAMP_TEST,
      'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-9-opt' % CHSET),
     # thunderbird
@@ -348,9 +348,9 @@ def test_tk_inbound_route(app, os, bits, processor, repo, push_date, expected):
 @pytest.mark.parametrize("app,os,bits,processor,build_type,expected", [
     # firefox
     ("firefox", 'linux', 64, 'x86_64', "asan",
-     'gecko.v2.mozilla-inbound.revision.%s.firefox.linux64-asan' % CHSET),
+     'gecko.v2.autoland.revision.%s.firefox.linux64-asan' % CHSET),
     ("firefox", 'linux', 64, 'x86_64', 'shippable',
-     'gecko.v2.mozilla-inbound.shippable.revision.%s.firefox.linux64-opt'
+     'gecko.v2.autoland.shippable.revision.%s.firefox.linux64-opt'
      % CHSET),
 ])
 def test_tk_inbound_route_with_build_type(app, os, bits, processor, build_type,

--- a/tests/unit/test_json_pushes.py
+++ b/tests/unit/test_json_pushes.py
@@ -28,7 +28,7 @@ def test_push(mocker):
     assert push.utc_date == datetime(1970, 1, 2, 10, 17, 36)
     assert str(push) == 'c'
     retry_get.assert_called_once_with(
-        'https://hg.mozilla.org/integration/mozilla-inbound/json-pushes'
+        'https://hg.mozilla.org/integration/autoland/json-pushes'
         '?changeset=validchangeset'
     )
 
@@ -76,9 +76,9 @@ def test_pushes_within_changes(mocker):
     assert pushes[2].changeset == 'c'
 
     retry_get.assert_has_calls([
-        call('https://hg.mozilla.org/integration/mozilla-inbound/json-pushes'
+        call('https://hg.mozilla.org/integration/autoland/json-pushes'
              '?changeset=fromchset'),
-        call('https://hg.mozilla.org/integration/mozilla-inbound/json-pushes'
+        call('https://hg.mozilla.org/integration/autoland/json-pushes'
              '?fromchange=fromchset&tochange=tochset'),
     ])
 


### PR DESCRIPTION
In some cases (e.g. bisecting GeckoView apps) we would attempt
to find builds on "mozilla-inbound" by default, which is now
discontinued.