### PR TITLE
Bug 1437591 - Add --arch argument to use specific CPU package.

### DIFF
--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -294,6 +294,13 @@ def create_parser(defaults):
     parser.add_argument('--debug', '-d', action='store_true',
                         help='Show the debug output.')
 
+    parser.add_argument("--arch",
+                        choices=("aarch64", "arm", "x86", "x86_64"),
+                        default=defaults['arch'],
+                        help=("CPU architecture of package."
+                              " Default: %s."
+                              % (defaults['arch'] or mozinfo.processor)))
+
     return parser
 
 
@@ -446,8 +453,9 @@ class Configuration(object):
 
         user_defined_bits = options.bits is not None
         options.bits = parse_bits(options.bits or mozinfo.bits)
+        options.arch = options.arch or mozinfo.processor
         fetch_config = create_config(options.app, mozinfo.os, options.bits,
-                                     mozinfo.processor)
+                                     options.arch)
         if options.build_type:
             try:
                 fetch_config.set_build_type(options.build_type)

--- a/mozregression/config.py
+++ b/mozregression/config.py
@@ -44,6 +44,7 @@ DEFAULTS = {
     'adb-profile-dir': None,
     'app': 'firefox',
     'approx-policy': 'auto',
+    'arch': None,
     'archive-base-url': ARCHIVE_BASE_URL,
     'background-dl-policy': 'cancel',
     'bits': None,

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -315,7 +315,13 @@ class FennecNightlyConfigMixin(NightlyConfigMixin):
     def get_nightly_repo_regex(self, date):
         repo = self.get_nightly_repo(date)
         if repo in ('mozilla-central',):
-            if date < datetime.date(2014, 12, 6):
+            if self.processor == 'aarch64':
+                repo += "-android-aarch64"
+            elif self.processor == 'x86':
+                repo += "-android-x86"
+            elif self.processor == 'x86_64':
+                repo += "-android-x86_64"
+            elif date < datetime.date(2014, 12, 6):
                 repo += "-android"
             elif date < datetime.date(2014, 12, 13):
                 repo += "-android-api-10"
@@ -415,8 +421,6 @@ class FirefoxInboundConfigMixin(InboundConfigMixin):
 
 
 class FennecInboundConfigMixin(InboundConfigMixin):
-    tk_name = 'android-api-11'
-
     def tk_inbound_routes(self, push):
         tk_name = self.tk_name
         if tk_name == 'android-api-11':
@@ -459,8 +463,8 @@ def create_config(name, os, bits, processor):
     :param os: os name, e.g 'linux', 'win' or 'mac'
     :param bits: the bit of the os as an int, e.g 32 or 64. Can be None
                  if the bits do not make sense (e.g. fennec)
-    :param processor: processor family, e.g 'x86', 'x86_86', 'ppc', 'ppc64' or
-                      'aarch64'
+    :param processor: processor family, e.g 'x86', 'x86_86', 'ppc', 'ppc64',
+                      'arm' or 'aarch64'
     """
     return REGISTRY.get(name)(os, bits, processor)
 
@@ -500,6 +504,17 @@ class FennecConfig(CommonConfig,
                    FennecInboundConfigMixin):
     BUILD_TYPES = ('opt', 'debug')
 
+    def __init__(self, os, bits, processor):
+        super(FennecConfig, self).__init__(os, bits, processor)
+        if processor == 'aarch64':
+            self.tk_name = 'android-aarch64'
+        elif processor == 'x86':
+            self.tk_name = 'android-x86'
+        elif processor == 'x86_64':
+            self.tk_name = 'android-x86_64'
+        else:
+            self.tk_name = 'android-api-11'
+
     def build_regex(self):
         return r'(target|fennec-.*)\.apk'
 
@@ -515,6 +530,17 @@ class GeckoViewExampleConfig(CommonConfig,
                              FennecNightlyConfigMixin,
                              FennecInboundConfigMixin):
     BUILD_TYPES = ('opt', 'debug')
+
+    def __init__(self, os, bits, processor):
+        super(GeckoViewExampleConfig, self).__init__(os, bits, processor)
+        if processor == 'aarch64':
+            self.tk_name = 'android-aarch64'
+        elif processor == 'x86':
+            self.tk_name = 'android-x86'
+        elif processor == 'x86_64':
+            self.tk_name = 'android-x86_64'
+        else:
+            self.tk_name = 'android-api-16'
 
     def build_regex(self):
         return r'geckoview_example\.apk'
@@ -532,7 +558,9 @@ class GeckoViewExampleConfig(CommonConfig,
 
 @REGISTRY.register('fennec-2.3', attr_value='fennec')
 class Fennec23Config(FennecConfig):
-    tk_name = 'android-api-9'
+    def __init__(self, os, bits, processor):
+        super(Fennec23Config, self).__init__(os, bits, None)
+        self.tk_name = 'android-api-9'
 
     def get_nightly_repo_regex(self, date):
         repo = self.get_nightly_repo(date)

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -201,6 +201,16 @@ class TestFennecConfig(unittest.TestCase):
         self.assertTrue(regex.match('fennec-36.0a1.multi.android-arm.txt'))
 
 
+class TestFennecX86Config(unittest.TestCase):
+    def setUp(self):
+        self.conf = create_config('fennec', 'linux', 64, 'x86')
+
+    def test_get_nightly_repo_regex(self):
+        regex = self.conf.get_nightly_repo_regex(datetime.date(2017,
+                                                               8, 30))
+        self.assertIn("mozilla-central-android-x86", regex)
+
+
 class TestFennec23Config(unittest.TestCase):
     def setUp(self):
         self.conf = create_config('fennec-2.3', 'linux', 64, None)
@@ -324,6 +334,8 @@ CHSET12 = "47856a214918"
     ("firefox", 'linux', 64, 'x86_64', 'try', TIMESTAMP_TEST,
      'gecko.v2.try.shippable.revision.%s.firefox.linux64-opt' % CHSET),
     # fennec
+    ("fennec", None, None, 'aarch64', None, TIMESTAMP_TEST,
+     'gecko.v2.autoland.revision.%s.mobile.android-aarch64-opt' % CHSET),
     ("fennec", None, None, None, None, TIMESTAMP_FENNEC_API_15 - 1,
      'gecko.v2.autoland.revision.%s.mobile.android-api-11-opt' % CHSET),
     ("fennec", None, None, None, None, TIMESTAMP_FENNEC_API_15,
@@ -332,6 +344,13 @@ CHSET12 = "47856a214918"
      'gecko.v2.autoland.revision.%s.mobile.android-api-16-opt' % CHSET),
     ("fennec-2.3", None, None, None, 'm-i', TIMESTAMP_TEST,
      'gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-9-opt' % CHSET),
+    # gve
+    ("gve", None, None, 'aarch64', None, TIMESTAMP_TEST,
+     'gecko.v2.autoland.revision.%s.mobile.android-aarch64-opt' % CHSET),
+    ("gve", None, None, 'x86', None, TIMESTAMP_TEST,
+     'gecko.v2.autoland.revision.%s.mobile.android-x86-opt' % CHSET),
+    ("gve", None, None, 'x86_64', None, TIMESTAMP_TEST,
+     'gecko.v2.autoland.revision.%s.mobile.android-x86_64-opt' % CHSET),
     # thunderbird
     ('thunderbird', 'win', 32, 'x86_64', 'comm-central', TIMESTAMP_TEST,
      'comm.v2.comm-central.revision.%s.thunderbird.win32-opt' % CHSET),


### PR DESCRIPTION
Actually, `mozregression` only supports arm package for Fennec and GVE. But I would like to support other architecture package such as x86_64 since it works on emulator.