### PR TITLE
Just use default requests, not requests[security]

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ mozprofile==2.5.0
 mozrunner==7.8.0
 mozversion==2.3.0
 redo==2.0.2
-requests[security]==2.22.0
+requests==2.23.0
 taskcluster==6.0.0
 
 # for some reason we need to specify a specific version of six


### PR DESCRIPTION
This was attempting to work around a bug with a very old version
of python2, no need for it now that we're on python 3.5+.