### PR TITLE
Fix launching with no URL in Mac GUI

### DIFF
--- a/gui/mozregui/build_runner.py
+++ b/gui/mozregui/build_runner.py
@@ -145,12 +145,14 @@ class AbstractBuildRunner(QObject):
         launcher_kwargs["addons"] = options["addons"]
         self.test_runner.launcher_kwargs = launcher_kwargs
 
+        launcher_kwargs["cmdargs"] = []
+
         if options["profile_persistence"] in ("clone-first", "reuse") or options["profile"]:
-            launcher_kwargs["cmdargs"] = launcher_kwargs.get("cmdargs", []) + ["--allow-downgrade"]
+            launcher_kwargs["cmdargs"] += ["--allow-downgrade"]
 
         # Thunderbird will fail to start if passed an URL arg
-        if "url" in options and fetch_config.app_name != "thunderbird":
-            launcher_kwargs["cmdargs"] = launcher_kwargs.get("cmdargs", []) + [options["url"]]
+        if options.get("url") and fetch_config.app_name != "thunderbird":
+            launcher_kwargs["cmdargs"] += [options["url"]]
 
         self.worker = self.worker_class(fetch_config, self.test_runner, self.download_manager)
         # Move self.bisector in the thread. This will


### PR DESCRIPTION
By default it would open the browser to `file:///`