### PR TITLE
Bug 1637164 - Iterate over a list rather than a live dict view.

### DIFF
--- a/mozregression/download_manager.py
+++ b/mozregression/download_manager.py
@@ -266,9 +266,12 @@ class DownloadManager(object):
         """
         Wait for all downloads to be finished.
         """
-        downloads = self._downloads.values()
-        for download in downloads:
-            download.wait(raise_if_error=raise_if_error)
+        # downloads can get removed from _downloads on completion during
+        # iteration so we can't use a live iterator, hence the list().
+        for download_key in list(self._downloads.keys()):
+            download = self._downloads.get(download_key)
+            if download:
+                download.wait(raise_if_error=raise_if_error)
 
     def download(self, url, fname, progress=None):
         """


### PR DESCRIPTION
In python2 the `values()` call here would have returned a list directly, but in
python3 it returns a live dict_values iterator, so if a download happens to
complete during this loop the other thread will remove it from the dict, causing
a "RuntimeError: dictionary changed size during iteration".