### PR TITLE
Bug 1631163 - Improve version compare

### DIFF
--- a/gui/mozregui/check_release.py
+++ b/gui/mozregui/check_release.py
@@ -1,3 +1,5 @@
+from packaging import version
+
 from PySide2.QtCore import QObject, Qt, QThread, QUrl, Slot
 from PySide2.QtGui import QDesktopServices
 from PySide2.QtWidgets import QLabel
@@ -43,7 +45,7 @@ class CheckRelease(QObject):
             return
 
         release_name = self.thread.tag_name
-        if release_name == mozregression_version:
+        if version.parse(release_name) <= version.parse(mozregression_version):
             return
 
         self.label.setText(

--- a/mozregression/mach_interface.py
+++ b/mozregression/mach_interface.py
@@ -8,6 +8,7 @@ break mach!
 from __future__ import absolute_import
 
 from argparse import Namespace
+from packaging import version
 
 from mozregression import __version__
 from mozregression.cli import create_parser
@@ -25,7 +26,7 @@ def new_release_on_pypi():
         pypi_version = pypi_latest_version()
     except Exception:
         return
-    if pypi_version != __version__:
+    if version.parse(__version__) < version.parse(pypi_version):
         return pypi_version
 
 

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -13,6 +13,7 @@ import colorama
 import mozfile
 import requests
 from mozlog import get_proxy_logger
+from packaging import version
 from requests.exceptions import HTTPError, RequestException
 
 from mozregression import __version__
@@ -288,15 +289,15 @@ def pypi_latest_version():
 
 def check_mozregression_version():
     try:
-        mozregression_version = pypi_latest_version()
+        pypi_version = pypi_latest_version()
     except (RequestException, KeyError, ValueError):
         LOG.critical("Unable to get latest version from pypi.")
         return
 
-    if __version__ != mozregression_version:
+    if version.parse(__version__) < version.parse(pypi_version):
         LOG.warning(
             "You are using mozregression version %s, "
-            "however version %s is available." % (__version__, mozregression_version)
+            "however version %s is available." % (__version__, pypi_version)
         )
 
         LOG.warning(


### PR DESCRIPTION
Prior to this change the version compare did not accurately compare
development versions against release versions, and as a result dev users
may have been shown an erroneous upgrade notice in the console or gui.

For example, dev version 4.0.5.dev8+gedaf3e9.d20200514 comes after
release version 4.0.4, and now there is no notice to upgrade to the
latter.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1631163

Closes #xxx

---

Only thing I'm unsure about is I think packaging comes standard

/cc @wlach 
