### PR TITLE
Bug 1437591 - Add support for x86_64 GVE builds

### DIFF
--- a/gui/mozregui/ui/intro.ui
+++ b/gui/mozregui/ui/intro.ui
@@ -35,20 +35,30 @@
     <widget class="QComboBox" name="bits_combo"/>
    </item>
    <item row="2" column="0">
+    <widget class="QLabel" name="arch_label">
+     <property name="text">
+      <string>Build architecture</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="arch_combo"/>
+   </item>
+   <item row="3" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Build Type</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QComboBox" name="build_type">
      <property name="toolTip">
       <string>Choose a build type you want.</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_3">
      <property name="toolTip">
       <string>you can choose a specific repository name here</string>
@@ -58,7 +68,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <widget class="QLineEdit" name="repository">
      <property name="toolTip">
       <string>repository like mozilla-inbound|mozilla-beta|...</string>
@@ -68,7 +78,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="url_label">
      <property name="toolTip">
       <string>enter a URL to pass to the app</string>
@@ -78,7 +88,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QLineEdit" name="url">
      <property name="toolTip">
       <string>URL such as example.org, https://mozilla.org, about:logo</string>

--- a/gui/mozregui/wizard.py
+++ b/gui/mozregui/wizard.py
@@ -59,6 +59,7 @@ class IntroPage(WizardPage):
         "application": "app_combo",
         "repository": "repository",
         "bits": "bits_combo",
+        "arch": "arch_combo",
         "build_type": "build_type",
         "url": "url",
     }
@@ -82,6 +83,7 @@ class IntroPage(WizardPage):
             bits_index = 0
         self.ui.bits_combo.setModel(self.bits_model)
         self.ui.bits_combo.setCurrentIndex(bits_index)
+        self.arch_model = QStringListModel()
         self.build_type_model = QStringListModel()
 
         self.ui.app_combo.currentIndexChanged.connect(self._set_fetch_config)
@@ -117,6 +119,15 @@ class IntroPage(WizardPage):
         bits = int(self.ui.bits_combo.currentText())
 
         self.fetch_config = create_config(app_name, mozinfo.os, bits, mozinfo.processor)
+
+        self.arch_model = QStringListModel(self.fetch_config.available_archs())
+        self.ui.arch_combo.setModel(self.arch_model)
+        if not self.arch_model.stringList():
+            self.ui.arch_label.hide()
+            self.ui.arch_combo.hide()
+        else:
+            self.ui.arch_label.show()
+            self.ui.arch_combo.show()
 
         self.build_type_model = QStringListModel(self.fetch_config.available_build_types())
         self.ui.build_type.setModel(self.build_type_model)
@@ -265,6 +276,8 @@ class Wizard(QWizard):
 
         fetch_config = self.page(self.pageIds()[0]).fetch_config
         fetch_config.set_repo(options["repository"])
+        if options["arch"]:
+            fetch_config.set_arch(options["arch"])
         fetch_config.set_build_type(options["build_type"])
 
         # create a profile if required

--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -267,6 +267,13 @@ def create_parser(defaults):
     )
 
     parser.add_argument(
+        "--arch",
+        choices=("arm", "x86_64"),
+        default=None,
+        help=("Force x86_64 build (only applies to GVE app). Default: arm"),
+    )
+
+    parser.add_argument(
         "-c",
         "--command",
         help=(
@@ -550,7 +557,14 @@ class Configuration(object):
 
         user_defined_bits = options.bits is not None
         options.bits = parse_bits(options.bits or mozinfo.bits)
-        fetch_config = create_config(options.app, mozinfo.os, options.bits, mozinfo.processor)
+        if options.arch is not None:
+            if options.app != "gve":
+                self.logger.warning("--arch ignored for non-GVE app.")
+                options.arch = None
+
+        fetch_config = create_config(
+            options.app, mozinfo.os, options.bits, mozinfo.processor, options.arch
+        )
         if options.build_type:
             try:
                 fetch_config.set_build_type(options.build_type)

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -93,10 +93,11 @@ class CommonConfig(object):
     BUILD_TYPE_FALLBACKS = {}
     app_name = None
 
-    def __init__(self, os, bits, processor):
+    def __init__(self, os, bits, processor, arch):
         self.os = os
         self.bits = bits
         self.processor = processor
+        self.arch = arch
         self.repo = None
         self.set_build_type("opt")
         self._used_build_index = 0
@@ -437,7 +438,7 @@ class ThunderbirdIntegrationConfigMixin(IntegrationConfigMixin):
 REGISTRY = ClassRegistry("app_name")
 
 
-def create_config(name, os, bits, processor):
+def create_config(name, os, bits, processor, arch=None):
     """
     Create and returns a configuration for the given name.
 
@@ -445,10 +446,13 @@ def create_config(name, os, bits, processor):
     :param os: os name, e.g 'linux', 'win' or 'mac'
     :param bits: the bit of the os as an int, e.g 32 or 64. Can be None
                  if the bits do not make sense (e.g. fennec)
-    :param processor: processor family, e.g 'x86', 'x86_86', 'ppc', 'ppc64' or
+    :param processor: processor family, e.g 'x86', 'x86_64', 'ppc', 'ppc64' or
                       'aarch64'
+    :param arch: architecture of the target build. e.g. From a linux64 machine
+                 you can run an ARM GVE build (default) or an x86_64 build,
+                 this is controlled by the arch parameter.
     """
-    return REGISTRY.get(name)(os, bits, processor)
+    return REGISTRY.get(name)(os, bits, processor, arch)
 
 
 @REGISTRY.register("firefox")
@@ -466,8 +470,8 @@ class FirefoxConfig(CommonConfig, FirefoxNightlyConfigMixin, FirefoxIntegrationC
         "opt": ("shippable", "pgo"),
     }
 
-    def __init__(self, os, bits, processor):
-        super(FirefoxConfig, self).__init__(os, bits, processor)
+    def __init__(self, os, bits, processor, arch):
+        super(FirefoxConfig, self).__init__(os, bits, processor, arch)
         self.set_build_type("shippable")
 
     def build_regex(self):
@@ -507,6 +511,11 @@ class FennecConfig(CommonConfig, FennecNightlyConfigMixin, FennecIntegrationConf
 @REGISTRY.register("gve")
 class GeckoViewExampleConfig(CommonConfig, FennecNightlyConfigMixin, FennecIntegrationConfigMixin):
     BUILD_TYPES = ("opt", "debug")
+
+    def __init__(self, os, bits, processor, arch):
+        super(GeckoViewExampleConfig, self).__init__(os, bits, processor, arch)
+        if arch == "x86_64":
+            self.tk_name = "android-x86_64"
 
     def build_regex(self):
         return r"geckoview_example\.apk"

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -97,7 +97,7 @@ class CommonConfig(object):
         self.os = os
         self.bits = bits
         self.processor = processor
-        self.arch = arch
+        self.set_arch(arch)
         self.repo = None
         self.set_build_type("opt")
         self._used_build_index = 0
@@ -143,6 +143,18 @@ class CommonConfig(object):
         run.
         """
         return (32, 64)
+
+    def available_archs(self):
+        """
+        Returns the available architectures for this application.
+        """
+        return []
+
+    def set_arch(self, arch):
+        """
+        Set the target build architecture for the application.
+        """
+        self.arch = arch
 
     def available_build_types(self):
         res = []
@@ -512,11 +524,6 @@ class FennecConfig(CommonConfig, FennecNightlyConfigMixin, FennecIntegrationConf
 class GeckoViewExampleConfig(CommonConfig, FennecNightlyConfigMixin, FennecIntegrationConfigMixin):
     BUILD_TYPES = ("opt", "debug")
 
-    def __init__(self, os, bits, processor, arch):
-        super(GeckoViewExampleConfig, self).__init__(os, bits, processor, arch)
-        if arch == "x86_64":
-            self.tk_name = "android-x86_64"
-
     def build_regex(self):
         return r"geckoview_example\.apk"
 
@@ -525,6 +532,15 @@ class GeckoViewExampleConfig(CommonConfig, FennecNightlyConfigMixin, FennecInteg
 
     def available_bits(self):
         return ()
+
+    def available_archs(self):
+        return ["arm", "x86_64"]
+
+    def set_arch(self, arch):
+        if arch == "x86_64":
+            self.tk_name = "android-x86_64"
+        else:
+            self.tk_name = "android-api-11"
 
     def should_use_archive(self):
         # GVE is not on archive.mozilla.org, only on taskcluster


### PR DESCRIPTION
I just cobbled this together quickly as a minimum viable thing for what I needed. Happy to clean it up as you see fit. I only saw the PR in #565 after I wrote and was kind of surprised at how similar they were, but that one seems more complicated. Also the problem with using `mozinfo.processor` as the default is that it seems to be based on the host machine which we don't really care about so much for Android. My PR keeps the `arch` separate from `processor`.