### PR TITLE
Remove some unnecessary octals modernize introduced

### DIFF
--- a/tests/unit/test_build_range.py
+++ b/tests/unit/test_build_range.py
@@ -242,17 +242,15 @@ def test_get_integration_range_with_dates(mocker, start_date, end_date, start_ca
 def test_get_nightly_range():
     fetch_config = create_config("firefox", "linux", 64, "x86_64")
 
-    b_range = build_range.get_nightly_range(
-        fetch_config, date(2015, 0o1, 0o1), date(2015, 0o1, 0o3)
-    )
+    b_range = build_range.get_nightly_range(fetch_config, date(2015, 1, 1), date(2015, 1, 3))
 
     assert isinstance(b_range, build_range.BuildRange)
     assert len(b_range) == 3
 
     b_range.build_info_fetcher.find_build_info = lambda v: v
-    assert b_range[0] == date(2015, 0o1, 0o1)
-    assert b_range[1] == date(2015, 0o1, 0o2)
-    assert b_range[2] == date(2015, 0o1, 0o3)
+    assert b_range[0] == date(2015, 1, 1)
+    assert b_range[1] == date(2015, 1, 2)
+    assert b_range[2] == date(2015, 1, 3)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_fetch_build_info.py
+++ b/tests/unit/test_fetch_build_info.py
@@ -88,13 +88,13 @@ class TestNightlyInfoFetcher(unittest.TestCase):
             "foo",
             "bar/",
         ]
-        urls = self.info_fetcher._get_urls(datetime.date(2014, 11, 0o1))
+        urls = self.info_fetcher._get_urls(datetime.date(2014, 11, 1))
         self.assertEqual(
             urls[0],
             fetch_configs.ARCHIVE_BASE_URL
             + "/firefox/nightly/2014/11/2014-11-01-03-02-05-mozilla-central/",
         )
-        urls = self.info_fetcher._get_urls(datetime.date(2014, 11, 0o2))
+        urls = self.info_fetcher._get_urls(datetime.date(2014, 11, 2))
         self.assertEqual(urls, [])
 
     def test_find_build_info(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -98,7 +98,7 @@ def test_app_bisect_nightlies_finished(create_app, mocker):
     nh = Mock(bad_date=date.today(), good_revision="c1", bad_revision="c2")
     NightlyHandler.return_value = nh
     assert app.bisect_nightlies() == 0
-    app.bisector.bisect.assert_called_once_with(ANY, date(2015, 0o6, 0o1), date(2015, 0o6, 0o2))
+    app.bisector.bisect.assert_called_once_with(ANY, date(2015, 6, 1), date(2015, 6, 2))
     assert create_app.find_in_log("Got as far as we can go bisecting nightlies...")
     app._bisect_integration.assert_called_once_with("c1", "c2", expand=config.DEFAULT_EXPAND)
 


### PR DESCRIPTION
These were introduced in f6f16683ebb8 since the month and date numbers were
zero-padded for alignment in Python 2, but it's invalid syntax in 3.