### PR TITLE
Bug 1651760 - Save GVE architecture in persisted filename

### DIFF
--- a/mozregression/build_info.py
+++ b/mozregression/build_info.py
@@ -165,7 +165,10 @@ class BuildInfo(object):
             persist_part = self._fetch_config.integration_persist_part()
         if persist_part:
             persist_part = "-" + persist_part
-        full_prefix = "{}{}--{}--".format(prefix, persist_part, self.repo_name)
+        extra = self._fetch_config.extra_persist_part()
+        if extra:
+            extra = extra + "--"
+        full_prefix = "{}{}--{}--{}".format(prefix, persist_part, self.repo_name, extra)
         if regex:
             full_prefix = re.escape(full_prefix)
             appname = self._fetch_config.build_regex()

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -205,6 +205,14 @@ class CommonConfig(object):
             or self.build_type not in ("opt", "asan", "shippable")
         )
 
+    def extra_persist_part(self):
+        """
+        Allow to add a part in the generated persist file name to distinguish
+        different builds that might be produced by a single config. Returns an
+        empty string by default.
+        """
+        return ""
+
 
 class NightlyConfigMixin(metaclass=ABCMeta):
     """
@@ -543,6 +551,7 @@ class GeckoViewExampleConfig(CommonConfig, FennecNightlyConfigMixin, FennecInteg
         return ["arm", "x86_64"]
 
     def set_arch(self, arch):
+        CommonConfig.set_arch(self, arch)
         if arch == "x86_64":
             self.tk_name = "android-x86_64"
         else:
@@ -551,6 +560,12 @@ class GeckoViewExampleConfig(CommonConfig, FennecNightlyConfigMixin, FennecInteg
     def should_use_archive(self):
         # GVE is not on archive.mozilla.org, only on taskcluster
         return False
+
+    def extra_persist_part(self):
+        if self.arch is None:
+            return "arm"
+        else:
+            return self.arch
 
 
 @REGISTRY.register("fennec-2.3", attr_value="fennec")

--- a/tests/unit/test_build_info.py
+++ b/tests/unit/test_build_info.py
@@ -115,3 +115,19 @@ def test_persist_filename(klass, extra, result):
         # fake that the fetch config should return the persist_part
         binfo._fetch_config.integration_persist_part = lambda: persist_part
     assert binfo.persist_filename == result
+
+
+@pytest.mark.parametrize(
+    "arch,result",
+    [
+        ("arm", "2015-09-01--mozilla-central--arm--url"),
+        ("x86_64", "2015-09-01--mozilla-central--x86_64--url"),
+        (None, "2015-09-01--mozilla-central--arm--url"),
+    ],
+)
+def test_persist_filename_with_arch(arch, result):
+    binfo_args = {
+        "fetch_config": create_config("gve", "linux", None, "x86", arch),
+    }
+    binfo = create_build_info(build_info.NightlyBuildInfo, **binfo_args)
+    assert binfo.persist_filename == result


### PR DESCRIPTION
This prevents architecture mismatches when installing a persisted APK.