### PR TITLE
Bug 1651401 - Add additional metrics on what builds are being retrieved

### DIFF
--- a/docs/glean/metrics.md
+++ b/docs/glean/metrics.md
@@ -30,10 +30,10 @@ The following metrics are added to the ping:
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
 | usage.app |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The name of the app being used (firefox, gve, etc.)  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1581647#c9)||never |
-| usage.bad_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The bad date parameter used in a bisection, if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401)||never |
-| usage.build_type |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The build type being bisected (opt, shippable, etc.)  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401)||never |
-| usage.good_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The good date parameter used in a bisection, if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401)||never |
-| usage.launch_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The launch parameter used when running a single build, if if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401)||never |
+| usage.bad_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The bad date parameter used in a bisection, if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401#c5)||never |
+| usage.build_type |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The build type being bisected (asan, debug, opt, pgo, shippable, ...)  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401#c5)||never |
+| usage.good_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The good date parameter used in a bisection, if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401#c5)||never |
+| usage.launch_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The launch parameter used when running a single build, if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401#c5)||never |
 | usage.variant |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The variant of mozregression used to perform the bisection (gui, console, mach, etc.)  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1581647#c9)||never |
 
 

--- a/docs/glean/metrics.md
+++ b/docs/glean/metrics.md
@@ -30,6 +30,10 @@ The following metrics are added to the ping:
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
 | usage.app |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The name of the app being used (firefox, gve, etc.)  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1581647#c9)||never |
+| usage.bad_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The bad date parameter used in a bisection, if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401)||never |
+| usage.build_type |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The build type being bisected (opt, shippable, etc.)  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401)||never |
+| usage.good_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The good date parameter used in a bisection, if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401)||never |
+| usage.launch_date |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The launch parameter used when running a single build, if if present and specified as a date  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1651401)||never |
 | usage.variant |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The variant of mozregression used to perform the bisection (gui, console, mach, etc.)  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1581647#c9)||never |
 
 

--- a/gui/mozregui/bisection.py
+++ b/gui/mozregui/bisection.py
@@ -220,8 +220,7 @@ class BisectRunner(AbstractBuildRunner):
         self.worker.finished.connect(self.bisection_finished)
         self.worker.handle_merge.connect(self.handle_merge)
         self.worker.choose_next_build.connect(self.choose_next_build)
-
-        good, bad = options.pop("good"), options.pop("bad")
+        good, bad = options.get("good"), options.get("bad")
         if (
             is_date_or_datetime(good)
             and is_date_or_datetime(bad)

--- a/gui/mozregui/build_runner.py
+++ b/gui/mozregui/build_runner.py
@@ -4,7 +4,7 @@ from mozregression.download_manager import BuildDownloadManager
 from mozregression.errors import LauncherError
 from mozregression.network import get_http_session
 from mozregression.persist_limit import PersistLimit
-from mozregression.telemetry import send_telemetry_ping
+from mozregression.telemetry import UsageMetrics, send_telemetry_ping
 from mozregression.test_runner import create_launcher
 from mozregui.global_prefs import apply_prefs, get_prefs
 from mozregui.log_report import log
@@ -170,7 +170,16 @@ class AbstractBuildRunner(QObject):
         # an action = instance of mozregression usage, so send
         # a usage ping (if telemetry is disabled, it will automatically
         # be discarded)
-        send_telemetry_ping("gui", fetch_config.app_name)
+        send_telemetry_ping(
+            UsageMetrics(
+                variant="gui",
+                appname=fetch_config.app_name,
+                build_type=fetch_config.build_type,
+                good=options.get("good"),
+                bad=options.get("bad"),
+                launch=getattr(self.worker, "launch_arg", None),
+            )
+        )
 
         self.stopped = False
         self.running_state_changed.emit(True)

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -28,7 +28,7 @@ from mozregression.json_pushes import JsonPushes
 from mozregression.launchers import REGISTRY as APP_REGISTRY
 from mozregression.network import set_http_session
 from mozregression.persist_limit import PersistLimit
-from mozregression.telemetry import send_telemetry_ping_oop
+from mozregression.telemetry import UsageMetrics, send_telemetry_ping_oop
 from mozregression.tempdir import safe_mkdtemp
 from mozregression.test_runner import CommandTestRunner, ManualTestRunner
 
@@ -325,7 +325,15 @@ def main(
 
         app = Application(config.fetch_config, config.options)
         send_telemetry_ping_oop(
-            mozregression_variant, config.fetch_config.app_name, config.enable_telemetry
+            UsageMetrics(
+                variant=mozregression_variant,
+                appname=config.fetch_config.app_name,
+                build_type=config.fetch_config.build_type,
+                good=config.options.good,
+                bad=config.options.bad,
+                launch=config.options.launch,
+            ),
+            config.enable_telemetry,
         )
 
         method = getattr(app, config.action)

--- a/mozregression/metrics.yaml
+++ b/mozregression/metrics.yaml
@@ -30,12 +30,12 @@ usage:
   build_type:
     type: string
     description: >
-      The build type being bisected (opt, shippable, etc.)
+      The build type being bisected (asan, debug, opt, pgo, shippable, ...)
     notification_emails: [wlachance@mozilla.com]
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401#c5
     expires: never
     send_in_pings:
       - usage
@@ -49,7 +49,7 @@ usage:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401#c5
     expires: never
     send_in_pings:
       - usage
@@ -63,7 +63,7 @@ usage:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401#c5
     expires: never
     send_in_pings:
       - usage
@@ -71,13 +71,13 @@ usage:
     type: datetime
     time_unit: day
     description: >
-      The launch parameter used when running a single build, if if present
+      The launch parameter used when running a single build, if present
       and specified as a date
     notification_emails: [wlachance@mozilla.com]
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401#c5
     expires: never
     send_in_pings:
       - usage

--- a/mozregression/metrics.yaml
+++ b/mozregression/metrics.yaml
@@ -27,3 +27,57 @@ usage:
     expires: never
     send_in_pings:
       - usage
+  build_type:
+    type: string
+    description: >
+      The build type being bisected (opt, shippable, etc.)
+    notification_emails: [wlachance@mozilla.com]
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+    expires: never
+    send_in_pings:
+      - usage
+  good_date:
+    type: datetime
+    time_unit: day
+    description: >
+      The good date parameter used in a bisection, if present and specified
+      as a date
+    notification_emails: [wlachance@mozilla.com]
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+    expires: never
+    send_in_pings:
+      - usage
+  bad_date:
+    type: datetime
+    time_unit: day
+    description: >
+      The bad date parameter used in a bisection, if present and specified as
+      a date
+    notification_emails: [wlachance@mozilla.com]
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+    expires: never
+    send_in_pings:
+      - usage
+  launch_date:
+    type: datetime
+    time_unit: day
+    description: >
+      The launch parameter used when running a single build, if if present
+      and specified as a date
+    notification_emails: [wlachance@mozilla.com]
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1651401
+    expires: never
+    send_in_pings:
+      - usage

--- a/mozregression/telemetry.py
+++ b/mozregression/telemetry.py
@@ -24,15 +24,12 @@ def initialize_telemetry(upload_enabled, allow_multiprocessing=False):
         application_id="org.mozilla.mozregression",
         application_version=__version__,
         upload_enabled=upload_enabled,
-        configuration=Configuration(
-            allow_multiprocessing=allow_multiprocessing, ping_tag="mozregression-test"
-        ),
+        configuration=Configuration(allow_multiprocessing=allow_multiprocessing),
         data_dir=mozregression_path / "data",
     )
 
 
 def _send_telemetry_ping(metrics):
-    print(metrics)
     METRICS.usage.variant.set(metrics.variant)
     METRICS.usage.app.set(metrics.appname)
     METRICS.usage.build_type.set(metrics.build_type)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -11,6 +11,7 @@ from mock import ANY, MagicMock, Mock, call, patch
 from mozregression import __version__, config, errors, main
 from mozregression.bisector import Bisection, Bisector, IntegrationHandler, NightlyHandler
 from mozregression.download_manager import BuildDownloadManager
+from mozregression.telemetry import UsageMetrics
 from mozregression.test_runner import CommandTestRunner, ManualTestRunner
 
 
@@ -258,7 +259,18 @@ class TestMain(unittest.TestCase):
         except SystemExit as exc:
             self.assertEqual(send_telemetry_ping_oop.call_count, 1)
             self.assertEqual(
-                send_telemetry_ping_oop.call_args, call("console", "firefox", telemetry_enabled)
+                send_telemetry_ping_oop.call_args,
+                call(
+                    UsageMetrics(
+                        "console",
+                        "firefox",
+                        self.app.fetch_config.build_type,
+                        self.app.options.good,
+                        self.app.options.bad,
+                        self.app.options.launch,
+                    ),
+                    telemetry_enabled,
+                ),
             )
             return exc.code
         else:


### PR DESCRIPTION
This will tell us the usage patterns of mozregression, which
helps inform what types of builds we need to keep around. Specifically,
track:

* build_type (e.g. shippable, opt, etc.)
* bisection/launch dates (if specified)