### PR TITLE
Bug 1657225 - Check nightly build regexs against filenames, not whole…

### DIFF
--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -202,9 +202,10 @@ class NightlyInfoFetcher(InfoFetcher):
         if not self.fetch_config.has_build_info:
             links += url_links(self.fetch_config.get_nightly_info_url(url))
         for link in links:
-            if "build_url" not in data and self.build_regex.search(link):
+            name = os.path.basename(link)
+            if "build_url" not in data and self.build_regex.match(name):
                 data["build_url"] = link
-            elif "build_txt_url" not in data and self.build_info_regex.search(link):
+            elif "build_txt_url" not in data and self.build_info_regex.match(name):
                 data["build_txt_url"] = link
         if data:
             # Check that we found all required data. The URL in build_url is

--- a/tests/unit/test_fetch_build_info.py
+++ b/tests/unit/test_fetch_build_info.py
@@ -132,6 +132,31 @@ bar/nightly/2014/11/2014-11-15-01-02-05-mozilla-central/",
             self.info_fetcher.find_build_info(datetime.date(2014, 11, 15))
 
 
+class TestNightlyInfoFetcher2(unittest.TestCase):
+    def setUp(self):
+        fetch_config = fetch_configs.create_config("firefox", "win", 64, "x86_64")
+        self.info_fetcher = fetch_build_info.NightlyInfoFetcher(fetch_config)
+
+    @patch("mozregression.fetch_build_info.url_links")
+    def test__find_build_info_from_url(self, url_links):
+        url_links.return_value = [
+            "http://foo/firefox/jsshell-win64.zip",
+            "http://foo/file1.txt.zip",
+            "http://foo/file2.txt",
+            "http://foo/firefox01linux-x86_64.txt",
+            "http://foo/firefox01linux-x86_64.tar.bz2",
+            "http://foo/firefox01win64.txt",
+            "http://foo/firefox01win64.zip",
+        ]
+        expected = {
+            "build_txt_url": "http://foo/firefox01win64.txt",
+            "build_url": "http://foo/firefox01win64.zip",
+        }
+        builds = []
+        self.info_fetcher._fetch_build_info_from_url("http://foo", 0, builds)
+        self.assertEqual(builds, [(0, expected)])
+
+
 class TestIntegrationInfoFetcher(unittest.TestCase):
     def setUp(self):
         fetch_config = fetch_configs.create_config("firefox", "linux", 64, "x86_64")


### PR DESCRIPTION
… URLs

Commit 6c7da9d1a97aea92591b7db3f407189444176c8b introduced a regression with
Thunderbird where it was downloading jsshell ZIPs on Windows instead of
Thunderbird builds, because the app name in the regex was matching against a
folder name in the URL, and on TB nightly archive pages jsshell is listed first
so gets picked.