### PR TITLE
Bug 1655682 - Stop trying old taskcluster root URL

### DIFF
--- a/mozregression/config.py
+++ b/mozregression/config.py
@@ -5,7 +5,6 @@ Reading and writing of the configuration file.
 from __future__ import absolute_import, print_function
 
 import os
-from datetime import datetime
 
 import mozinfo
 from configobj import ConfigObj, ParseError
@@ -20,9 +19,6 @@ DEFAULT_CONF_FNAME = os.path.expanduser(
 TC_CREDENTIALS_FNAME = os.path.expanduser(
     os.path.join("~", ".mozilla", "mozregression", "taskcluster-credentials.json")
 )
-OLD_TC_ROOT_URL = "https://taskcluster.net"
-TC_ROOT_URL = "https://firefox-ci-tc.services.mozilla.com"
-TC_ROOT_URL_MIGRATION_FLAG_DATE = datetime.strptime("2019-11-09", "%Y-%M-%d")
 ARCHIVE_BASE_URL = "https://archive.mozilla.org/pub"
 # when a bisection range needs to be expanded, the following value is used to
 # specify how many builds we try (if 20, we will try 20 before the lower limit,

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -425,12 +425,12 @@ class IntegrationConfigMixin(metaclass=ABCMeta):
         """
         self._tk_credentials = creds
 
-    def tk_options(self, root_url):
+    def tk_options(self):
         """
         Returns the takcluster options, including the credentials required to
         download private artifacts.
         """
-        tk_options = {"rootUrl": root_url}
+        tk_options = {"rootUrl": "https://firefox-ci-tc.services.mozilla.com"}
         if self.tk_needs_auth():
             tk_options.update({"credentials": self._tk_credentials})
         return tk_options


### PR DESCRIPTION
This is effectively a manual/partial backout of
f5f7466dd14e4a4e863cbc061a38025d152f7d99

Not only has the old taskcluster been decommissioned and thus no longer returns
anything, but changes to taskcluster-urls in version 13.0.1 were leading to
mozregression terminating when it passed the old TC root URLs.