### PR TITLE
Bug 1659829 - Updates to GeckoViewExample / Fennec support

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -485,7 +485,7 @@ class FennecIntegrationConfigMixin(IntegrationConfigMixin):
                 "opt" if build_type == "shippable" else build_type,
             )
             self._inc_used_build()
-            return
+        return
 
 
 class ThunderbirdIntegrationConfigMixin(IntegrationConfigMixin):
@@ -601,7 +601,11 @@ class FennecConfig(CommonConfig, FennecNightlyConfigMixin, FennecIntegrationConf
 
 @REGISTRY.register("gve")
 class GeckoViewExampleConfig(CommonConfig, FennecNightlyConfigMixin, FennecIntegrationConfigMixin):
-    BUILD_TYPES = ("opt", "debug")
+    BUILD_TYPES = ("shippable", "opt", "debug")
+    BUILD_TYPE_FALLBACKS = {
+        "shippable": ("opt",),
+        "opt": ("shippable",),
+    }
 
     def build_regex(self):
         return r"geckoview_example\.apk"
@@ -631,20 +635,6 @@ class GeckoViewExampleConfig(CommonConfig, FennecNightlyConfigMixin, FennecInteg
             return "arm"
         else:
             return self.arch
-
-
-@REGISTRY.register("fennec-2.3", attr_value="fennec")
-class Fennec23Config(FennecConfig):
-    tk_name = "android-api-9"
-
-    def get_nightly_repo_regex(self, date):
-        repo = self.get_nightly_repo(date)
-        if repo == "mozilla-central":
-            if date < datetime.date(2014, 12, 6):
-                repo = "mozilla-central-android"
-            else:
-                repo = "mozilla-central-android-api-9"
-        return self._get_nightly_repo_regex(date, repo)
 
 
 @REGISTRY.register("jsshell", disable_in_gui=True)

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -217,18 +217,17 @@ class TestFennecConfig(unittest.TestCase):
         self.assertTrue(regex.match("fennec-36.0a1.multi.android-arm.txt"))
 
 
-class TestFennec23Config(unittest.TestCase):
+class TestGVEConfig(unittest.TestCase):
     def setUp(self):
-        self.conf = create_config("fennec-2.3", "linux", 64, None)
+        self.conf = create_config("gve", "linux", 64, None)
 
-    def test_class_attr_name(self):
-        self.assertEqual(self.conf.app_name, "fennec")
-
-    def test_get_nightly_repo_regex(self):
-        regex = self.conf.get_nightly_repo_regex(datetime.date(2014, 12, 5))
-        self.assertIn("mozilla-central-android", regex)
-        regex = self.conf.get_nightly_repo_regex(datetime.date(2015, 1, 1))
-        self.assertIn("mozilla-central-android-api-9", regex)
+    def test_fallbacking(self):
+        assert self.conf.build_type == "opt"
+        self.conf._inc_used_build()
+        assert self.conf.build_type == "shippable"
+        # Check we wrap
+        self.conf._inc_used_build()
+        assert self.conf.build_type == "opt"
 
 
 class TestGetBuildUrl(unittest.TestCase):
@@ -400,15 +399,6 @@ CHSET12 = "47856a214918"
             TIMESTAMP_FENNEC_API_16,
             "gecko.v2.mozilla-central.revision.%s.mobile.android-api-16-opt" % CHSET,
         ),
-        (
-            "fennec-2.3",
-            None,
-            None,
-            None,
-            "m-i",
-            TIMESTAMP_TEST,
-            "gecko.v2.mozilla-inbound.revision.%s.mobile.android-api-9-opt" % CHSET,
-        ),
         # thunderbird
         (
             "thunderbird",
@@ -456,6 +446,23 @@ def test_tk_route(app, os, bits, processor, repo, push_date, expected):
             "x86_64",
             "shippable",
             "gecko.v2.mozilla-central.shippable.revision.%s.firefox.linux64-opt" % CHSET,
+        ),
+        # gve
+        (
+            "gve",
+            "linux",
+            64,
+            "x86_64",
+            "opt",
+            "gecko.v2.mozilla-central.revision.%s.mobile.android-api-16-opt" % CHSET,
+        ),
+        (
+            "gve",
+            "linux",
+            64,
+            "x86_64",
+            "shippable",
+            "gecko.v2.mozilla-central.shippable.revision.%s.mobile.android-api-16-opt" % CHSET,
         ),
     ],
 )


### PR DESCRIPTION
* Remove fennec 2.3 support (the time when this was something we'd
  want to test is long past)
* Allow GVE to have shippable builds, now that we have them (fallback
  to opt if not there)
* Fix bug in fennec/gve fallback build selection