### PR TITLE
Set default "bad" date to one year ago

### DIFF
--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -451,18 +451,7 @@ def get_default_date_range(fetch_config):
     Compute the default date range (first, last) to bisect.
     """
     last_date = datetime.date.today()
-    if fetch_config.app_name == "jsshell":
-        if fetch_config.os == "win" and fetch_config.bits == 64:
-            first_date = datetime.date(2014, 5, 27)
-        elif fetch_config.os == "linux" and "asan" in fetch_config.build_type:
-            first_date = datetime.date(2013, 9, 1)
-        else:
-            first_date = datetime.date(2012, 4, 18)
-    elif fetch_config.os == "win" and fetch_config.bits == 64:
-        # first firefox build date for win64 is 2010-05-28
-        first_date = datetime.date(2010, 5, 28)
-    else:
-        first_date = datetime.date(2009, 1, 1)
+    first_date = datetime.date.today() - datetime.timedelta(days=365)
 
     return first_date, last_date
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -131,8 +131,7 @@ def test_app_bisect_integration_finished(create_app, same_chsets):
         (["--addon=a b c", "--addon=d"], "'--addon=a b c' --addon=d"),
         (["--find-fix", "--arg=a b"], "--find-fix '--arg=a b'"),
         (["--profile=pro file"], "'--profile=pro file'"),
-        (["-g", "2015-11-01"], "--good=2015-11-01"),
-        (["--bad=2015-11-03"], "--bad=2015-11-03"),
+        (["-g", "2015-11-01", "-b", "2015-11-03"], "--good=2015-11-01 --bad=2015-11-03"),
     ],
 )
 def test_app_bisect_nightlies_user_exit(create_app, argv, expected_log, mocker):


### PR DESCRIPTION
We used to have some convoluted logic to pick the earliest possible
build, but this is silly default behaviour. Most of the time regressions
are relatively recent, if they're not people can always specify their
own date manually.