### PR TITLE
Bug 1661607 - Tweak the workaround to work for python 3.6 as well

### DIFF
--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -133,7 +133,7 @@ class IntegrationInfoFetcher(InfoFetcher):
                 try:
                     build_date = datetime.strptime(run["resolved"], "%Y-%m-%dT%H:%M:%S.%fZ")
                 except ValueError:
-                    build_date = datetime.strptime(run["resolved"], "%Y-%m-%dT%H:%M:%S.%f%z")
+                    build_date = datetime.strptime(run["resolved"], "%Y-%m-%dT%H:%M:%S.%f+00:00")
                 break
 
         if run_id is None:


### PR DESCRIPTION
In python 3.6, the %z format specifier does not match time
zone strings containing a colon, such as "+00:00".

We know the string will in practice always be "+00:00", so
just match that exactly.