### PR TITLE
Bug 1672831 - Strip whitespace from buildids and changesets in the GUI

### DIFF
--- a/gui/mozregui/utils.py
+++ b/gui/mozregui/utils.py
@@ -78,10 +78,10 @@ class BuildSelection(QWidget):
         elif currentw == self.ui.s_release:
             return parse_date(date_of_release(str(self.ui.release.currentText())))
         elif currentw == self.ui.s_buildid:
-            buildid = self.ui.buildid.text()
+            buildid = self.ui.buildid.text().strip()
             try:
                 return parse_date(buildid)
             except DateFormatError:
                 raise DateFormatError(buildid, "Not a valid build id: `%s`")
         elif currentw == self.ui.s_changeset:
-            return self.ui.changeset.text()
+            return self.ui.changeset.text().strip()

--- a/gui/tests/test_utils.py
+++ b/gui/tests/test_utils.py
@@ -34,8 +34,10 @@ def test_switch_to_release_widget(build_selection, qtbot):
     "widname,value,expected",
     [
         ("buildid", "20150102101112", datetime.datetime(2015, 1, 2, 10, 11, 12)),
+        ("buildid", " \t20150102101112  ", datetime.datetime(2015, 1, 2, 10, 11, 12)),
         ("release", "40", datetime.date(2015, 5, 11)),
         ("changeset", "abc123", "abc123"),
+        ("changeset", " abc123\t  ", "abc123"),
     ],
 )
 def test_get_value(build_selection, qtbot, widname, value, expected):


### PR DESCRIPTION
So that it doesn't construct changesets URLs with spaces and fail to find
builds, or fail to parse dates from buildids with trailing spaces.