### PR TITLE
Migrate to native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99
+  allow:
+    - dependency-type: all


### PR DESCRIPTION
The config is almost the same as the auto-suggested one on dependabot.com, but
with the addition of the new `dependency-type: all` setting, which hopefully
will manage to update indirect dependencies as well and lead to less PRs
failing due to "ERROR: In --require-hashes mode, all requirements must have
their versions pinned with ==. These do not:".
Though I'm not clear if it will cope with new additions to the dependency
graph, which seem to be what's causing such errors.