### PR TITLE
Bug 1680309 - Handle invalid dates better

### DIFF
--- a/mozregression/dates.py
+++ b/mozregression/dates.py
@@ -8,7 +8,7 @@ import calendar
 import datetime
 import re
 
-from mozregression.errors import DateFormatError
+from mozregression.errors import DateFormatError, DateValueError
 
 
 def parse_date(date_string):
@@ -25,7 +25,10 @@ def parse_date(date_string):
     matched = regex.match(date_string)
     if not matched:
         raise DateFormatError(date_string)
-    return datetime.date(int(matched.group(1)), int(matched.group(2)), int(matched.group(3)))
+    try:
+        return datetime.date(int(matched.group(1)), int(matched.group(2)), int(matched.group(3)))
+    except ValueError:
+        raise DateValueError(date_string)
 
 
 def to_datetime(date):

--- a/mozregression/dates.py
+++ b/mozregression/dates.py
@@ -27,8 +27,8 @@ def parse_date(date_string):
         raise DateFormatError(date_string)
     try:
         return datetime.date(int(matched.group(1)), int(matched.group(2)), int(matched.group(3)))
-    except ValueError:
-        raise DateValueError(date_string)
+    except ValueError as ex:
+        raise DateValueError(date_string, ex)
 
 
 def to_datetime(date):

--- a/mozregression/errors.py
+++ b/mozregression/errors.py
@@ -25,6 +25,15 @@ class DateFormatError(MozRegressionError):
         MozRegressionError.__init__(self, format % date_string)
 
 
+class DateValueError(MozRegressionError):
+    """
+    Raised when the integer values of a parsed date are invalid.
+    """
+
+    def __init__(self, date_string, format="Invalid date value: `%s`"):
+        MozRegressionError.__init__(self, format % date_string)
+
+
 class LauncherNotRunnable(MozRegressionError):
     """
     Raised when a :class:`mozregression.launchers.Launcher` can not be

--- a/mozregression/errors.py
+++ b/mozregression/errors.py
@@ -30,8 +30,8 @@ class DateValueError(MozRegressionError):
     Raised when the integer values of a parsed date are invalid.
     """
 
-    def __init__(self, date_string, format="Invalid date value: `%s`"):
-        MozRegressionError.__init__(self, format % date_string)
+    def __init__(self, date_string, ex, format="Invalid date value: `%s`, %s"):
+        MozRegressionError.__init__(self, format % (date_string, ex))
 
 
 class LauncherNotRunnable(MozRegressionError):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -26,6 +26,8 @@ class TestParseDate(unittest.TestCase):
         self.assertRaises(errors.DateFormatError, cli.parse_date, "invalid_format")
         # test invalid buildid (43 is not a valid day)
         self.assertRaises(errors.DateFormatError, cli.parse_date, "20151143030248")
+        self.assertRaises(errors.DateValueError, cli.parse_date, "2020-11-0")
+        self.assertRaises(errors.DateValueError, cli.parse_date, "2020-13-01")
 
 
 class TestParseBits(unittest.TestCase):


### PR DESCRIPTION
Don't terminate and dump a traceback.
This doesn't spot typos like 2020-003-01 that won't match the regex `re.compile(r"(\d{4})\-(\d{1,2})\-(\d{1,2})")`.  We could potentially loosen the regex, either to maybe `re.compile(r"(\d{3,5})\-(\d{1,3})\-(\d{1,3})")` or just use `\d+`.  However those at least never crashed, we just try to use them as a hash instead.