### PR TITLE
Add coveralls to requirements and pin to 3.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Test
         run: |
           coverage run -m pytest tests
-          pip install coveralls; coveralls --service=github-actions
+          coveralls --service=github-actions
         env:
           GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
       - name: Test
         run: |
           coverage run -m pytest -v gui/tests
-          pip install coveralls; coveralls --service=github-actions
+          coveralls --service=github-actions
         env:
           GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
       - name: Test
         run: |
           coverage run -m pytest -v gui/tests
-          pip3 install coveralls; coveralls --service=github-actions
+          coveralls --service=github-actions
         env:
           GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -195,6 +195,12 @@ coverage==5.5 \
     --hash=sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079 \
     --hash=sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d \
     --hash=sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6
+    # via
+    #   -r dev.in
+    #   coveralls
+coveralls==3.1.0 \
+    --hash=sha256:172fb79c5f61c6ede60554f2cac46deff6d64ee735991fb2124fb414e188bdb4 \
+    --hash=sha256:9b3236e086627340bf2c95f89f757d093cbed43d17179d3f4fb568c347e7d29a
     # via -r dev.in
 diskcache==5.2.1 \
     --hash=sha256:1805acd5868ac10ad547208951a1190a0ab7bbff4e70f9a07cde4dbdfaa69f64 \
@@ -207,6 +213,9 @@ distro==1.5.0 \
 future==0.18.2 \
     --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d \
     # via pefile
+docopt==0.6.2 \
+    --hash=sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
+    # via coveralls
 glean-parser==2.2.0 \
     --hash=sha256:41726b795773d9ea0fcaf0893ade517da1aa5c2f279079a0cad7e0b91df80c2f \
     --hash=sha256:6ec26c99d93b9cad0b19495a8a63598acce5911d93a7820cbc6fa768475ce7b2
@@ -516,6 +525,7 @@ requests==2.25.1 \
     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
     # via
     #   -r base.in
+    #   coveralls
     #   mozinstall
     #   taskcluster
 setuptools-scm==5.0.2 \

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,5 @@
 coverage
+coveralls==3.1.0  # pinning to an older version, need to update CI for 3.2.0+
 mock
 pytest
 pytest-mock


### PR DESCRIPTION
Should fix current breakage and hopefully prevent it from happening in the future.
