### PR TITLE
github: disable dependabot version updates (bug 1780012)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 99
-  allow:
-    - dependency-type: all


### PR DESCRIPTION
The current dependabot version updates does not allow configuring different Python versions for different requirement files. Until this bug is fixed, dependabot version updates (non-security) should be disabled.