### PR TITLE
launchers: Disable TB update by policy (bug 1783694)

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -402,6 +402,10 @@ class ThunderbirdRegressionProfile(ThunderbirdProfile):
 class ThunderbirdLauncher(MozRunnerLauncher):
     profile_class = ThunderbirdRegressionProfile
 
+    def _install(self, dest):
+        super(ThunderbirdLauncher, self)._install(dest)
+        self._disableUpdateByPolicy()
+
 
 class AndroidLauncher(Launcher):
     app_info = None


### PR DESCRIPTION
Although the `app.update.auto:false` and `app.update.enabled:false` preferences are set, these have no effect on recent versions of Thunderbird due to their removal in [Bug 1420514](https://bugzilla.mozilla.org/show_bug.cgi?id=1420514) (ported to TB in [Bug 1479289](https://bugzilla.mozilla.org/show_bug.cgi?id=1479289)).  The replacement policy mechanism of setting `policies.DisableAppUpdate:true` in `distribution/policies.json` was added to `FirefoxLauncher` in 68ece936, but was not added to `ThunderbirdLauncher`.  This PR applies the same change so that app updates are disabled for Thunderbird.

Thanks for considering,
Kevin