### PR TITLE
launchers: handle invalid codesign on macOS 13 (bug 1781111)

### DIFF
--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -289,7 +289,7 @@ class TestMozRunnerLauncher__codesign(unittest.TestCase):
     [
         (launchers.CodesignResult.PASS, 0),
         (launchers.CodesignResult.UNSIGNED, 1),
-        (launchers.CodesignResult.INVALID, 0),
+        (launchers.CodesignResult.INVALID, 1),
         (launchers.CodesignResult.OTHER, 0),
     ],
 )


### PR DESCRIPTION
- add check for invalid code signature if os is >= 13