### PR TITLE
launchers: compare strings directly in os_version (bug 1802616)

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -387,7 +387,7 @@ class FirefoxLauncher(MozRunnerLauncher):
 
         if (
             mozinfo.os == "mac"
-            and mozinfo.os_version.version.version[0] >= 13
+            and mozinfo.os_version >= "13.0"
             and self._codesign_verify(self.appdir) == CodesignResult.INVALID
         ):
             LOG.warning(f"codesign verification failed for {self.appdir}, resigning...")


### PR DESCRIPTION
Do not use mozinfo.os_version.version any more as it was modified in a newer version of StringVersion. Instead, use string comparison directly.