### PR TITLE
requirements: update minimum glean-sdk version (bug 1810534)

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,9 @@ PyInstaller==5.7.0
 beautifulsoup4==4.11.1
 colorama==0.4.5
 configobj==5.0.6
-glean-sdk==51.4.0
+glean-sdk==52.0.1; sys.platform != 'darwin'
+# See https://github.com/pypa/pip/issues/11573.
+https://files.pythonhosted.org/packages/ca/c2/960b918ec5cc4c2d45c33771da91ebd9109e6d2ba700e4debcac72569bab/glean_sdk-52.0.1-cp36-abi3-macosx_10_7_universal2.whl; sys.platform == 'darwin'
 importlib-metadata==4.2.0
 mozdevice>=4.1.0,<5
 mozfile==2.1.0

--- a/requirements/requirements-3.10-Linux.txt
+++ b/requirements/requirements-3.10-Linux.txt
@@ -281,13 +281,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk==52.0.1 ; sys_platform != "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.10-Windows.txt
+++ b/requirements/requirements-3.10-Windows.txt
@@ -287,13 +287,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk==52.0.1 ; sys_platform != "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.10-macOS.txt
+++ b/requirements/requirements-3.10-macOS.txt
@@ -283,13 +283,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk @ https://files.pythonhosted.org/packages/ca/c2/960b918ec5cc4c2d45c33771da91ebd9109e6d2ba700e4debcac72569bab/glean_sdk-52.0.1-cp36-abi3-macosx_10_7_universal2.whl ; sys_platform == "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.11-Linux.txt
+++ b/requirements/requirements-3.11-Linux.txt
@@ -281,13 +281,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk==52.0.1 ; sys_platform != "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.11-Windows.txt
+++ b/requirements/requirements-3.11-Windows.txt
@@ -287,13 +287,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk==52.0.1 ; sys_platform != "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.11-macOS.txt
+++ b/requirements/requirements-3.11-macOS.txt
@@ -283,13 +283,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk @ https://files.pythonhosted.org/packages/ca/c2/960b918ec5cc4c2d45c33771da91ebd9109e6d2ba700e4debcac72569bab/glean_sdk-52.0.1-cp36-abi3-macosx_10_7_universal2.whl ; sys_platform == "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.7-Linux.txt
+++ b/requirements/requirements-3.7-Linux.txt
@@ -285,13 +285,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk==52.0.1 ; sys_platform != "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.8-Linux.txt
+++ b/requirements/requirements-3.8-Linux.txt
@@ -281,13 +281,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk==52.0.1 ; sys_platform != "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.9-Linux.txt
+++ b/requirements/requirements-3.9-Linux.txt
@@ -281,13 +281,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk==52.0.1 ; sys_platform != "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.9-Windows.txt
+++ b/requirements/requirements-3.9-Windows.txt
@@ -287,13 +287,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk==52.0.1 ; sys_platform != "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \

--- a/requirements/requirements-3.9-macOS.txt
+++ b/requirements/requirements-3.9-macOS.txt
@@ -283,13 +283,14 @@ glean-parser==6.4.0 \
     # via
     #   -r linters.in
     #   glean-sdk
-glean-sdk==51.4.0 \
-    --hash=sha256:4b9055de21c07cb208a8e68a9fb6a67c95a9ae23278aeece2a1911186a01dd74 \
-    --hash=sha256:655b752737bf75eec2bcba2cdca184870c2b742d106548de7778ac75369046fc \
-    --hash=sha256:895fdd2feb75246c77e90c52175fd722f842fe59ce42051630fa5ff7c00398ba \
-    --hash=sha256:a93d45ff4d650533ab86bd264725973e26b1efe88e4d0c91df48b65c8ebbf996 \
-    --hash=sha256:b0bc8c34efc454a08498933d28396499b6e62e19a233dfc1b4cd309308c8d394 \
-    --hash=sha256:ea739655dc6b94c58cf4ab7997694428e573d6ffb6d50bbfaaac2ba8d646cfac
+glean-sdk @ https://files.pythonhosted.org/packages/ca/c2/960b918ec5cc4c2d45c33771da91ebd9109e6d2ba700e4debcac72569bab/glean_sdk-52.0.1-cp36-abi3-macosx_10_7_universal2.whl ; sys_platform == "darwin" \
+    --hash=sha256:0483c24602084b58b133790705d7c130369beefa11f8355a9d14152ec88425c1 \
+    --hash=sha256:9945ad5594fa291875e1a6764b7948506fa341342f7aa00791980f0ef6fb2ddc \
+    --hash=sha256:b506320d9084fd0b6c8be3db02c186546dbc1f4c80f438a5c73a7737f32ad9a9 \
+    --hash=sha256:cdbc2405ebb7b7dc43a7f0edf0bd8af946dafbf413ec330f551cd65c4ec3e510 \
+    --hash=sha256:de35fe4b2f1638c85b6a065f8a9e0fd92c82c17223d66e76f2290153ff378298 \
+    --hash=sha256:e652d3ed188d98b2802e2472a02955c8bf4186b19abe58ffa8bff2a977ace967 \
+    --hash=sha256:e922db4bbbf3255fd0093cdf5423ad4e89fcf65831a8fb6faee1a37a2e8b3998
     # via -r base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \


### PR DESCRIPTION
glean-sdk 52.0.1 has a universal2 wheel which we can install in the virtual environment in order to build a universal2 bundle for mozregression-gui.

See https://github.com/pypa/pip/issues/11573 for more information on why the package has to be pinned in this way in the macOS requirements.