### PR TITLE
log: set ALLOW_COLOR to False if not sys.stdout (bug 1811930)

### DIFF
--- a/mozregression/log.py
+++ b/mozregression/log.py
@@ -13,7 +13,7 @@ from colorama import Back, Fore, Style
 from mozlog.handlers import LogLevelFilter, StreamHandler
 from mozlog.structuredlog import StructuredLogger, set_default_logger
 
-ALLOW_COLOR = sys.stdout.isatty()
+ALLOW_COLOR = sys.stdout.isatty() if sys.stdout else False
 
 
 def _format_seconds(total):


### PR DESCRIPTION
As of PyInstaller 5.7.0, sys.stdout is changed from NullWriter to None
for GUI applications on Windows.