### PR TITLE
launchers: handle invalid codesign on macOS 13 (bug 1817001)

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -214,6 +214,15 @@ class MozRunnerLauncher(Launcher):
         # arguments since macOS 10, however this was tested on macOS 12.
         return call(["codesign", "--force", "--deep", "--sign", "-", appdir])
 
+    @property
+    def _codesign_invalid_on_macOS_13(self):
+        """Return True if codesign verify fails on macOS 13+, otherwise reutrn False."""
+        return (
+            mozinfo.os == "mac"
+            and mozinfo.os_version >= "13.0"
+            and self._codesign_verify(self.appdir) == CodesignResult.INVALID
+        )
+
     def _install(self, dest):
         self.tempdir = safe_mkdtemp()
         try:
@@ -385,11 +394,7 @@ class FirefoxLauncher(MozRunnerLauncher):
         super(FirefoxLauncher, self)._install(dest)
         self._disableUpdateByPolicy()
 
-        if (
-            mozinfo.os == "mac"
-            and mozinfo.os_version >= "13.0"
-            and self._codesign_verify(self.appdir) == CodesignResult.INVALID
-        ):
+        if self._codesign_invalid_on_macOS_13:
             LOG.warning(f"codesign verification failed for {self.appdir}, resigning...")
             self._codesign_sign(self.appdir)
 
@@ -413,6 +418,10 @@ class ThunderbirdLauncher(MozRunnerLauncher):
     def _install(self, dest):
         super(ThunderbirdLauncher, self)._install(dest)
         self._disableUpdateByPolicy()
+
+        if self._codesign_invalid_on_macOS_13:
+            LOG.warning(f"codesign verification failed for {self.appdir}, resigning...")
+            self._codesign_sign(self.appdir)
 
 
 class AndroidLauncher(Launcher):

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -395,7 +395,7 @@ class FirefoxLauncher(MozRunnerLauncher):
         self._disableUpdateByPolicy()
 
         if self._codesign_invalid_on_macOS_13:
-            LOG.warning(f"codesign verification failed for {self.appdir}, resigning...")
+            LOG.warning(f"codesign verification failed for {self.appdir}, re-signing...")
             self._codesign_sign(self.appdir)
 
 
@@ -420,7 +420,7 @@ class ThunderbirdLauncher(MozRunnerLauncher):
         self._disableUpdateByPolicy()
 
         if self._codesign_invalid_on_macOS_13:
-            LOG.warning(f"codesign verification failed for {self.appdir}, resigning...")
+            LOG.warning(f"codesign verification failed for {self.appdir}, re-signing...")
             self._codesign_sign(self.appdir)
 
 

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -216,7 +216,7 @@ class MozRunnerLauncher(Launcher):
 
     @property
     def _codesign_invalid_on_macOS_13(self):
-        """Return True if codesign verify fails on macOS 13+, otherwise reutrn False."""
+        """Return True if codesign verify fails on macOS 13+, otherwise return False."""
         return (
             mozinfo.os == "mac"
             and mozinfo.os_version >= "13.0"


### PR DESCRIPTION
Move common functionality to `MozRunnerLauncher` and call it in both `FirefoxLauncher` and `ThunderbirdLauncher`.