### PR TITLE
workflows: run compile jobs in parallel (bug 1810224)

### DIFF
--- a/.github/workflows/compile-requirements.yml
+++ b/.github/workflows/compile-requirements.yml
@@ -79,4 +79,4 @@ jobs:
           find temp-requirements -name "requirements-*" -type f -exec mv -f -t requirements {} +
           git add -A
           git commit -m "Automatically generated requirements"
-          git push -f https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          until git push -f https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git; do git pull --rebase; done

--- a/.github/workflows/run-compile-requirements.yml
+++ b/.github/workflows/run-compile-requirements.yml
@@ -16,7 +16,6 @@ jobs:
       python: '["3.7", "3.8", "3.9", "3.10", "3.11"]'
 
   call-compile-requirements-windows:
-    needs: call-compile-requirements-linux
     uses: ./.github/workflows/compile-requirements.yml
     with:
       requirements_files: '["base.in dev.in gui-dev.in gui.in linters.in"]'
@@ -24,7 +23,6 @@ jobs:
       python: '["3.9", "3.10", "3.11"]'
 
   call-compile-requirements-macos:
-    needs: call-compile-requirements-windows
     uses: ./.github/workflows/compile-requirements.yml
     with:
       requirements_files: '["base.in dev.in gui-dev.in gui.in linters.in"]'


### PR DESCRIPTION
Previously, jobs were run in series to avoid two or more jobs pushing at the same time. This can be handled by rebasing until a push is successful while running jobs in parallel, saving a significant amount of time.