### PR TITLE
gui: update __init__ to use super() (bug 1836097)

### DIFF
--- a/gui/mozregui/bisection.py
+++ b/gui/mozregui/bisection.py
@@ -33,8 +33,12 @@ class GuiBisector(QObject, Bisector):
     handle_merge = Signal(object, str, str, str)
 
     def __init__(self, fetch_config, test_runner, download_manager, download_in_background=True):
-        QObject.__init__(self)
-        Bisector.__init__(self, fetch_config, test_runner, download_manager)
+        super().__init__(
+            fetch_config=fetch_config,
+            test_runner=test_runner,
+            download_manager=download_manager,
+            dl_in_background=download_in_background,
+        )
         self.bisection = None
         self.mid = None
         self.build_infos = None

--- a/gui/mozregui/build_runner.py
+++ b/gui/mozregui/build_runner.py
@@ -54,7 +54,7 @@ class GuiTestRunner(QObject):
     evaluate_finished = Signal()
 
     def __init__(self):
-        QObject.__init__(self)
+        super().__init__()
         self.verdict = None
         self.launcher = None
         self.launcher_kwargs = {}
@@ -97,7 +97,7 @@ class AbstractBuildRunner(QObject):
     worker_class = None
 
     def __init__(self, mainwindow):
-        QObject.__init__(self)
+        super().__init__()
         self.mainwindow = mainwindow
         self.thread = None
         self.worker = None

--- a/gui/mozregui/check_release.py
+++ b/gui/mozregui/check_release.py
@@ -22,7 +22,7 @@ class CheckReleaseThread(QThread):
 
 class CheckRelease(QObject):
     def __init__(self, mainwindow):
-        QObject.__init__(self, mainwindow)
+        super().__init__()
         self.mainwindow = mainwindow
         self.thread = CheckReleaseThread()
         self.thread.finished.connect(self.on_release_found)

--- a/gui/mozregui/check_release.py
+++ b/gui/mozregui/check_release.py
@@ -22,7 +22,7 @@ class CheckReleaseThread(QThread):
 
 class CheckRelease(QObject):
     def __init__(self, mainwindow):
-        super().__init__()
+        super().__init__(mainwindow)
         self.mainwindow = mainwindow
         self.thread = CheckReleaseThread()
         self.thread.finished.connect(self.on_release_found)

--- a/gui/mozregui/crash_reporter.py
+++ b/gui/mozregui/crash_reporter.py
@@ -44,7 +44,7 @@ class CrashReporter(QObject):
     got_exception = Signal(tuple)
 
     def __init__(self, app):
-        super().__init__()
+        super().__init__(app)
         self._sys_except_hook = sys.excepthook
         self.app = app
         self.allow_dialog = True

--- a/gui/mozregui/crash_reporter.py
+++ b/gui/mozregui/crash_reporter.py
@@ -44,7 +44,7 @@ class CrashReporter(QObject):
     got_exception = Signal(tuple)
 
     def __init__(self, app):
-        QObject.__init__(self, app)
+        super().__init__()
         self._sys_except_hook = sys.excepthook
         self.app = app
         self.allow_dialog = True

--- a/gui/mozregui/single_runner.py
+++ b/gui/mozregui/single_runner.py
@@ -14,7 +14,7 @@ class SingleBuildWorker(QObject):
     error = Signal(object)
 
     def __init__(self, fetch_config, test_runner, download_manager):
-        QObject.__init__(self)
+        super().__init__()
         self.fetch_config = fetch_config
         self.test_runner = test_runner
         self.download_manager = download_manager


### PR DESCRIPTION
See: https://bugreports.qt.io/browse/PYSIDE-2304 and https://bugreports.qt.io/browse/PYSIDE-1564. For relevant release/dev notes: https://www.qt.io/blog/qt-for-python-6.5 and https://wiki.qt.io/Qt_for_Python_Development_Notes#20._April_2023.

This only affects classes with multiple base classes.