### PR TITLE
telemetry: fix windows string comparison in mozinfo (bug 1838490)

### DIFF
--- a/mozregression/telemetry.py
+++ b/mozregression/telemetry.py
@@ -52,7 +52,7 @@ def get_system_info():
             info["mac_version"] = platform.mac_ver()[0]
         except (AttributeError, IndexError):
             info["mac_version"] = UNKNOWN
-    elif mozinfo.os == "windows":
+    elif mozinfo.os == "win":
         try:
             # Fetch "version" from tuple containing Windows version information.
             # See https://docs.python.org/3/library/platform.html#windows-platform.


### PR DESCRIPTION
The original implementation was using the wrong string comparison to determine if the user is running Windows. This PR fixes this. See [mozinfo.py](https://searchfox.org/mozilla-central/source/testing/mozbase/mozinfo/mozinfo/mozinfo.py#87).