### PR TITLE
build_range: skip TC builds that have expired artifacts (bug 1841685)

### DIFF
--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -160,7 +160,7 @@ class IntegrationInfoFetcher(InfoFetcher):
             # build_url is an alias that redirects via a 303 status code.
             status_code = requests.head(build_url, allow_redirects=True).status_code
             if status_code != 200:
-                error = f"Taskcluster file {build_url} could not be fetched ({status_code})."
+                error = f"Taskcluster file {build_url} not available (status code: {status_code})."
                 raise BuildInfoNotFound(error)
         return IntegrationBuildInfo(
             self.fetch_config,


### PR DESCRIPTION
- do a HEAD request to check if GVE artifacts are available from taskcluster
- raise a `BuildInfoNotFound` error when artifacts are no longer available