### PR TITLE
workflows: add Python 3.11, Windows CLI tests to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: setup
@@ -58,6 +58,25 @@ jobs:
           source env/bin/activate
           coverage run -m pytest tests
           coveralls --service=github
+
+  build-and-test-windows-cli:
+    runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
+      - name: Install dependencies and run tests
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/requirements-3.11-Windows.txt
+          python -m pip install -e .
+          python -m pytest tests
 
   build-and-test-linux-gui:
     runs-on: ${{ matrix.os }}

--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+import sys
 import tempfile
 import unittest
 from subprocess import CalledProcessError
@@ -243,6 +244,10 @@ class TestMozRunnerLauncher__codesign(unittest.TestCase):
         call.assert_called_with(["codesign", "--force", "--deep", "--sign", "-", "/"])
         call.assert_called_once()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="os.path.normpath behaviour on Windows interferes with this test",
+    )
     @patch("mozregression.launchers.mozinfo")
     @patch("mozregression.launchers.mozinstall")
     def test__codesign_assert_resigned_if_unsigned(self, mozinstall, mozinfo):
@@ -268,6 +273,10 @@ class TestMozRunnerLauncher__codesign(unittest.TestCase):
                 _codesign_sign.assert_not_called()
                 _codesign_verify.assert_not_called()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="os.path.normpath behaviour on Windows interferes with this test",
+    )
     @patch("mozregression.launchers.mozinfo")
     @patch("mozregression.launchers.mozinstall")
     def test__codesign_assert_not_resigned_if_not_unsigned(self, mozinstall, mozinfo):


### PR DESCRIPTION
- add new build-and-test-windows-cli job (bug 1844111)
- skip test that fails on windows (bug 1844111)
- add Python 3.11 to test matrix (bug 1843853)