### PR TITLE
setup: update programming language classifiers (bug 1843854)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,10 @@ setup(
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
     ],
 )


### PR DESCRIPTION
Python 3.6 was dropped in #1083.