### PR TITLE
workflows: add missing libraries for Ubuntu builds (bug 1828122)

### DIFF
--- a/.github/workflows/deploy-gui.yml
+++ b/.github/workflows/deploy-gui.yml
@@ -17,20 +17,26 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
-      - name: setup
+      - name: setup Ubuntu 20.04
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt install libxcb-xinerama0 libegl-dev -y
+      - name: setup Ubuntu 22.04
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt install libxcb-xinerama0 libxcb-cursor0 libegl-dev qt6-qpa-plugins -y
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m venv env
           source env/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install -r requirements/requirements-3.9-Linux.txt
+          python -m pip install -r requirements/requirements-3.10-Linux.txt
           python -m pip install -e .
       - name: Build
         run: |

--- a/.github/workflows/upload-gui-to-workflow.yml
+++ b/.github/workflows/upload-gui-to-workflow.yml
@@ -18,10 +18,16 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-      - name: setup
+      - name: setup Ubuntu 20.04
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt install libxcb-xinerama0 libegl-dev -y
+      - name: setup Ubuntu 22.04
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt install libxcb-xinerama0 libxcb-cursor0 libegl-dev qt6-qpa-plugins -y
       - name: Set up Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
This missing library causes a Qt platform plugin error since it does not get copied over when the app is being bundled. Upgrade Python while we're at it.