### PR TITLE
workflows: add push tag workflow to upload artifacts (bug 1849402)

### DIFF
--- a/.github/workflows/upload-gui-to-workflow.yml
+++ b/.github/workflows/upload-gui-to-workflow.yml
@@ -1,0 +1,110 @@
+name: Build and upload GUI packages to workflow
+
+on:
+  push:
+    tags:
+      - build-*
+
+jobs:
+  build-and-publish-linux-gui:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+          - ubuntu-22.04
+    env:
+      DISPLAY: ":99.0"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup
+        run: |
+          sudo apt-get update
+          sudo apt install libxcb-xinerama0 libegl-dev -y
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m venv env
+          source env/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/requirements-3.9-Linux.txt
+          python -m pip install -e .
+      - name: Build
+        run: |
+          source env/bin/activate
+          python gui/build.py bundle
+          mv gui/mozregression-gui.tar.gz gui/mozregression-gui-${{ matrix.os }}.tar.gz
+          ls -alh gui/mozregression-gui-${{ matrix.os }}.tar.gz
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./gui/mozregression-gui-${{ matrix.os }}.tar.gz
+          name: mozregression-gui-${{ matrix.os }}.tar.gz
+
+  build-and-publish-mac-gui:
+    runs-on: macos-latest
+    env:
+      # We need the official Python, because the GA ones only support newer macOS versions
+      # The deployment target is picked up by the Python build tools automatically
+      PYTHON_VERSION: 3.11.1
+      MACOSX_DEPLOYMENT_TARGET: 10.13
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Python
+        run: curl https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-macos11.pkg -o "python.pkg"
+      - name: Install Python
+        # See: https://github.com/actions/virtual-environments/issues/1256#issuecomment-770270252
+        run: |
+          sudo installer -pkg python.pkg -target /
+          python3 -m venv env
+          source env/bin/activate
+          which python
+          python --version
+      - name: Install dependencies
+        run: |
+          source env/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/requirements-3.11-macOS.txt
+          python -m pip install -e .
+      - name: Build
+        run: |
+          source env/bin/activate
+          python gui/build.py bundle
+          ls -alh gui/mozregression-gui-app-bundle.tar.gz
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./gui/mozregression-gui-app-bundle.tar.gz
+          name: mozregression-gui-app-bundle.tar.gz
+
+  build-and-publish-windows-gui:
+    runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/requirements-3.10-Windows.txt
+          python -m pip install -e .
+      - name: Build and test
+        run: |
+          python gui\build.py bundle --nsis-path "C:\\Program Files (x86)\\NSIS"
+          python gui\build.py test
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./gui/wininst/mozregression-gui.exe
+          name: mozregression-gui-unsigned.exe


### PR DESCRIPTION
This is a new workflow in order to build artifacts without requiring a release tag. This will reduce the noise (i.e., dev releases) when testing changes that require full builds. Currently set to build any tag that starts with `build-`. It is left up to the tag author to delete tags that are no longer needed.