### PR TITLE
fetch_configs, launchers: add Fenix nightlies support (bug 1556042)

### DIFF
--- a/docs/_data/mozregression_supported_apps.yml
+++ b/docs/_data/mozregression_supported_apps.yml
@@ -9,3 +9,7 @@
 - name: fennec
   url: https://wiki.mozilla.org/Mobile/Fennec
   description: Firefox for Android
+
+- name: fenix
+  url: https://github.com/mozilla-mobile/firefox-android/blob/main/fenix/README.md
+  description: Firefox for Android

--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -581,12 +581,11 @@ class Configuration(object):
             if options.app not in ("gve", "fenix"):
                 self.logger.warning("--arch ignored for non Android apps.")
                 options.arch = None
-            else:
-                if options.arch not in arch_options[options.app]:
-                    raise MozRegressionError(
-                        f"Invalid arch ({options.arch}) specified for app ({options.app}). "
-                        f"Valid options are: {', '.join(arch_options[options.app])}."
-                    )
+            elif options.arch not in arch_options[options.app]:
+                raise MozRegressionError(
+                    f"Invalid arch ({options.arch}) specified for app ({options.app}). "
+                    f"Valid options are: {', '.join(arch_options[options.app])}."
+                )
 
         fetch_config = create_config(
             options.app, mozinfo.os, options.bits, mozinfo.processor, options.arch

--- a/mozregression/cli.py
+++ b/mozregression/cli.py
@@ -276,9 +276,16 @@ def create_parser(defaults):
 
     parser.add_argument(
         "--arch",
-        choices=("arm", "x86_64", "aarch64"),
+        choices=(
+            "aarch64",
+            "arm",
+            "arm64-v8a",
+            "armeabi-v7a",
+            "x86",
+            "x86_64",
+        ),
         default=None,
-        help=("Force alternate build (only applies to GVE app). Default: arm"),
+        help=("Force alternate build (applies to GVE and Fenix)."),
     )
 
     parser.add_argument(
@@ -554,12 +561,32 @@ class Configuration(object):
         """
         options = self.options
 
+        arch_options = {
+            "gve": [
+                "aarch64",
+                "arm",
+                "x86_64",
+            ],
+            "fenix": [
+                "arm64-v8a",
+                "armeabi-v7a",
+                "x86",
+                "x86_64",
+            ],
+        }
+
         user_defined_bits = options.bits is not None
         options.bits = parse_bits(options.bits or mozinfo.bits)
         if options.arch is not None:
-            if options.app != "gve":
-                self.logger.warning("--arch ignored for non-GVE app.")
+            if options.app not in ("gve", "fenix"):
+                self.logger.warning("--arch ignored for non Android apps.")
                 options.arch = None
+            else:
+                if options.arch not in arch_options[options.app]:
+                    raise MozRegressionError(
+                        f"Invalid arch ({options.arch}) specified for app ({options.app}). "
+                        f"Valid options are: {', '.join(arch_options[options.app])}."
+                    )
 
         fetch_config = create_config(
             options.app, mozinfo.os, options.bits, mozinfo.processor, options.arch

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -382,6 +382,19 @@ class FennecNightlyConfigMixin(NightlyConfigMixin):
         return self._get_nightly_repo_regex(date, repo)
 
 
+class FenixNightlyConfigMixin(NightlyConfigMixin):
+    nightly_base_repo_name = "fenix"
+    arch_regex_bits = ""
+
+    def _get_nightly_repo(self, date):
+        return "fenix"
+
+    def get_nightly_repo_regex(self, date):
+        repo = self.get_nightly_repo(date)
+        repo += self.arch_regex_bits  # e.g., ".*arm64.*".
+        return self._get_nightly_repo_regex(date, repo)
+
+
 class IntegrationConfigMixin(metaclass=ABCMeta):
     """
     Define the integration-related required configuration.
@@ -605,6 +618,36 @@ class FennecConfig(CommonConfig, FennecNightlyConfigMixin, FennecIntegrationConf
 
     def available_bits(self):
         return ()
+
+
+@REGISTRY.register("fenix")
+class FenixConfig(CommonConfig, FenixNightlyConfigMixin):
+    def build_regex(self):
+        return r"fenix-.*\.apk"
+
+    def available_bits(self):
+        return ()
+
+    def available_archs(self):
+        return [
+            "arm64-v8a",
+            "armeabi-v7a",
+            "x86",
+            "x86_64",
+        ]
+
+    def set_arch(self, arch):
+        CommonConfig.set_arch(self, arch)
+        mapping = {
+            "arm64-v8a": "-.+-android-arm64-v8a",
+            "armeabi-v7a": "-.+-android-armeabi-v7a",
+            "x86": "-.+-android-x86",
+            "x86_64": "-.+-android-x86_64",
+        }
+        self.arch_regex_bits = mapping.get(self.arch, "")
+
+    def should_use_archive(self):
+        return True
 
 
 @REGISTRY.register("gve")

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -638,6 +638,7 @@ class FenixConfig(CommonConfig, FenixNightlyConfigMixin):
 
     def set_arch(self, arch):
         CommonConfig.set_arch(self, arch)
+        # Map "arch" value to one that can be used in the nightly repo regex lookup.
         mapping = {
             "arm64-v8a": "-.+-android-arm64-v8a",
             "armeabi-v7a": "-.+-android-armeabi-v7a",

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -493,6 +493,31 @@ class AndroidLauncher(Launcher):
         if self.adb.exists(self.remote_profile):
             self.adb.rm(self.remote_profile, recursive=True)
 
+    def launch_browser(
+        self,
+        app_name,
+        activity,
+        intent="android.intent.action.VIEW",
+        moz_env=None,
+        url=None,
+        wait=True,
+        fail_if_running=True,
+        timeout=None,
+    ):
+        extras = {}
+        extras["args"] = f"-profile {self.remote_profile}"
+
+        self.adb.launch_application(
+            app_name,
+            activity,
+            intent,
+            url=url,
+            extras=extras,
+            wait=wait,
+            fail_if_running=fail_if_running,
+            timeout=timeout,
+        )
+
     def get_app_info(self):
         return self.app_info
 
@@ -504,7 +529,17 @@ class FennecLauncher(AndroidLauncher):
 
     def _launch(self):
         LOG.debug("Launching fennec")
-        self.adb.launch_fennec(self.package_name, extra_args=["-profile", self.remote_profile])
+        self.launch_browser(self.package_name, "org.mozilla.gecko.BrowserApp")
+
+
+@REGISTRY.register("fenix")
+class FenixLauncher(AndroidLauncher):
+    def _get_package_name(self):
+        return "org.mozilla.fenix"
+
+    def _launch(self):
+        LOG.debug("Launching fenix")
+        self.launch_browser(self.package_name, ".IntentReceiverActivity")
 
 
 @REGISTRY.register("gve")

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -216,7 +216,7 @@ class TestExtendedAndroidConfig:
     def test_build_regex(self, app_name):
         conf = create_config(app_name, "linux", 64, None)
         regex = re.compile(conf.build_regex())
-        assert bool(regex.match(f"{app_name}-110.0b1.multi.android-arm64-v8a.apk")) is True
+        assert regex.match(f"{app_name}-110.0b1.multi.android-arm64-v8a.apk") is not None
 
     def test_build_info_regex(self, app_name):
         if app_name != "fennec":


### PR DESCRIPTION
- add "fenix" as an app option in the cli
- update available arch options to include newer ones
- Add FenixNightlyConfigMixin and FenixConfig classes
- create new helper method `AndroidBrowser.launch_browser`
- move `adb.launch_fennec` calls to `adb.launch_application`
- create FenixLauncher class
- parametrize existing Fennec tests and update to support Fenix
- update cli help text
- add fenix as supported app in docs