### PR TITLE
launchers: pass URL arg to Android launchers (bug 1852787)

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -482,7 +482,14 @@ class AndroidLauncher(Launcher):
             self.adb.rm(self.remote_profile, recursive=True)
         LOG.debug("Pushing profile to device (%s -> %s)" % (profile.profile, self.remote_profile))
         self.adb.push(profile.profile, self.remote_profile)
-        self._launch()
+        if cmdargs and len(cmdargs) == 1 and not cmdargs[0].startswith("-"):
+            url = cmdargs[0]
+        else:
+            url = None
+        if isinstance(self, (FenixLauncher, FennecLauncher, FocusLauncher)):
+            self._launch(url)
+        else:
+            self._launch()
 
     def _wait(self):
         while self.adb.process_exist(self.package_name):
@@ -527,9 +534,9 @@ class FennecLauncher(AndroidLauncher):
     def _get_package_name(self):
         return "org.mozilla.fennec"
 
-    def _launch(self):
+    def _launch(self, url=None):
         LOG.debug("Launching fennec")
-        self.launch_browser(self.package_name, "org.mozilla.gecko.BrowserApp")
+        self.launch_browser(self.package_name, "org.mozilla.gecko.BrowserApp", url=url)
 
 
 @REGISTRY.register("fenix")
@@ -537,9 +544,9 @@ class FenixLauncher(AndroidLauncher):
     def _get_package_name(self):
         return "org.mozilla.fenix"
 
-    def _launch(self):
+    def _launch(self, url=None):
         LOG.debug("Launching fenix")
-        self.launch_browser(self.package_name, ".IntentReceiverActivity")
+        self.launch_browser(self.package_name, ".IntentReceiverActivity", url=url)
 
 
 @REGISTRY.register("focus")
@@ -547,11 +554,12 @@ class FocusLauncher(AndroidLauncher):
     def _get_package_name(self):
         return "org.mozilla.focus.nightly"
 
-    def _launch(self):
+    def _launch(self, url=None):
         LOG.debug("Launching focus")
         self.launch_browser(
             self.package_name,
             "org.mozilla.focus.activity.IntentReceiverActivity",
+            url=url,
         )
 
 

--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -487,7 +487,7 @@ class AndroidLauncher(Launcher):
         else:
             url = None
         if isinstance(self, (FenixLauncher, FennecLauncher, FocusLauncher)):
-            self._launch(url)
+            self._launch(url=url)
         else:
             self._launch()
 

--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -474,6 +474,25 @@ class TestExtendedAndroidLauncher:
         launcher.wait()
         self.adb.process_exist.assert_called_with(package_name)
 
+    def test_start_with_url(self, launcher_class, package_name, intended_activity, **kwargs):
+        with patch(
+            f"mozregression.launchers.{launcher_class.__name__}._create_profile"
+        ) as _create_profile:
+            # Force use of existing profile
+            _create_profile.return_value = self.profile
+            launcher = self.create_launcher(launcher_class=launcher_class)
+            launcher.start(profile="my_profile", cmdargs=("https://example.org/",))
+            self.adb.launch_application.assert_called_once_with(
+                package_name,
+                intended_activity,
+                "android.intent.action.VIEW",
+                url="https://example.org/",
+                extras={"args": f"-profile {self.remote_profile_path}"},
+                wait=True,
+                fail_if_running=True,
+                timeout=None,
+            )
+
 
 class Zipfile(object):
     def __init__(self, *a):


### PR DESCRIPTION
- add support for URL arg to be passed to the browser
- add tests