### PR TITLE
fetch_configs: fix MRO in FirefoxL10nConfig (bug 1874400)

### DIFF
--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -626,7 +626,7 @@ class ThunderbirdConfig(
 
 
 @REGISTRY.register("thunderbird-l10n", attr_value="thunderbird")
-class ThunderbirdL10nConfig(L10nMixin, CommonConfig, ThunderbirdL10nNightlyConfigMixin):
+class ThunderbirdL10nConfig(L10nMixin, ThunderbirdL10nNightlyConfigMixin, CommonConfig):
     pass
 
 

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -614,7 +614,7 @@ class FirefoxConfig(CommonConfig, FirefoxNightlyConfigMixin, FirefoxIntegrationC
 
 
 @REGISTRY.register("firefox-l10n", attr_value="firefox")
-class FirefoxL10nConfig(CommonConfig, FirefoxL10nNightlyConfigMixin, L10nMixin):
+class FirefoxL10nConfig(L10nMixin, FirefoxL10nNightlyConfigMixin, CommonConfig):
     pass
 
 


### PR DESCRIPTION
This was in the correct order for `ThunderbirdL10nConfig`, however this was not the case for `FirefoxL10nConfig`. This PR fixes this problem, ensuring that the definition for the build regex is defined correctly.

Edit: also move `CommonConfig` to the right in `ThunderbirdL10nConfig`, since `ThunderbirdL10nNightlyConfigMixin` may have been overridden in that case as well.