### PR TITLE
telemetry: replace (deprecated) pkg_resources with importlib (bug 1894839)

### DIFF
--- a/mozregression/telemetry.py
+++ b/mozregression/telemetry.py
@@ -7,14 +7,14 @@ import distro
 import mozinfo
 from glean import Configuration, Glean, load_metrics, load_pings
 from mozlog import get_proxy_logger
-from pkg_resources import resource_filename
+import importlib.resources
 
 from mozregression import __version__
 from mozregression.dates import is_date_or_datetime, to_datetime
 
 LOG = get_proxy_logger("telemetry")
-PINGS = load_pings(resource_filename(__name__, "pings.yaml"))
-METRICS = load_metrics(resource_filename(__name__, "metrics.yaml"))
+PINGS = load_pings(importlib.resources.files(__name__) / "pings.yaml")
+METRICS = load_metrics(importlib.resources.files(__name__) / "metrics.yaml")
 
 UsageMetrics = namedtuple(
     "UsageMetrics",


### PR DESCRIPTION
This makes it work with Python 3.12

(or it will as soon as [I do a Glean release too](https://bugzilla.mozilla.org/show_bug.cgi?id=1894595)).
Note that I couldn't find anything how to actually manually update the dependencies; that seems undocumented but requires a push to a `requirements` branch to trigger CI for it? I will need help with that.