### PR TITLE
telemetry: use importlib_resources instead of pkg_resources (bug 1894839)

### DIFF
--- a/mozregression/telemetry.py
+++ b/mozregression/telemetry.py
@@ -4,17 +4,18 @@ from multiprocessing import Process
 from pathlib import Path
 
 import distro
+import importlib_resources
 import mozinfo
 from glean import Configuration, Glean, load_metrics, load_pings
 from mozlog import get_proxy_logger
-from pkg_resources import resource_filename
 
 from mozregression import __version__
 from mozregression.dates import is_date_or_datetime, to_datetime
 
 LOG = get_proxy_logger("telemetry")
-PINGS = load_pings(resource_filename(__name__, "pings.yaml"))
-METRICS = load_metrics(resource_filename(__name__, "metrics.yaml"))
+
+PINGS = load_pings(importlib_resources.files(__name__) / "pings.yaml")
+METRICS = load_metrics(importlib_resources.files(__name__) / "metrics.yaml")
 
 UsageMetrics = namedtuple(
     "UsageMetrics",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ DEPENDENCIES = [
     "colorama>=0.4.1",
     "configobj>=5.0.6",
     "distro>=1.8.0",
+    "importlib_resources>= 5.10",
     "mozdevice>=4.1.0,<5",
     "mozfile>=2.0.0",
     "mozinfo>=1.1.0",
@@ -54,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
     ],
 )


### PR DESCRIPTION
[importlib.resources.files](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files) behaves differently across different versions of Python, is not available in Python 3.8 (which is still supported at this time) and the `importlib_resources` package bridges those differences.

Since this bug fixes Python 3.12 support, also add this to the list of classifiers.