### PR TITLE
 workflows: fix macOS gui builds to match test runner (bug 1902706)

### DIFF
--- a/.github/workflows/deploy-gui.yml
+++ b/.github/workflows/deploy-gui.yml
@@ -53,6 +53,8 @@ jobs:
           asset_content_type: application/gzip
 
   build-and-publish-mac-gui:
+    # macos-13 is the latest runner (as of time of writing) that does not cause a
+    # _tkinter import error during the build.
     runs-on: macos-13
     env:
       # We need the official Python, because the GA ones only support newer macOS versions

--- a/.github/workflows/deploy-gui.yml
+++ b/.github/workflows/deploy-gui.yml
@@ -53,11 +53,11 @@ jobs:
           asset_content_type: application/gzip
 
   build-and-publish-mac-gui:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       # We need the official Python, because the GA ones only support newer macOS versions
       # The deployment target is picked up by the Python build tools automatically
-      PYTHON_VERSION: 3.11.1
+      PYTHON_VERSION: 3.12.4
       MACOSX_DEPLOYMENT_TARGET: 10.13
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
- update Python version to 3.12.4
- fix macOS runner version to 13

This should have been done as part of https://github.com/mozilla/mozregression/pull/1690/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721.