### PR TITLE
workflows: fix outdated/hardcoded requirements file (bug 1902706)

### DIFF
--- a/.github/workflows/deploy-gui.yml
+++ b/.github/workflows/deploy-gui.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           source env/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install -r requirements/requirements-3.11-macOS.txt
+          python -m pip install -r requirements/requirements-3.12-macOS.txt
           python -m pip install -e .
       - name: Build
         run: |


### PR DESCRIPTION
Another missed change to line up with the previous updates to the test workflow.

In the future, we should somehow consolidate the common aspects of these configurations into a central place or import them from elsewhere, since changes to `deploy-gui.yml` do not get tested as part of the usual CI, and only as part of deployments.