### PR TITLE
workflows: add Ubuntu 24.04 to test matrix (bug 1903562)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,11 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: ubuntu-24.04
+            python-version: "3.8"
     steps:
       - uses: actions/checkout@v3
       - name: setup


### PR DESCRIPTION
- add ubuntu-24.04 to test matrix
- exclude Python 3.8 from the Ubuntu 24.04 run as it is not available