### PR TITLE
gui: replace usage of stdlib pipes library with shlex (bug 1914478)

### DIFF
--- a/gui/build.py
+++ b/gui/build.py
@@ -7,7 +7,7 @@ See python build.py --help
 import argparse
 import glob
 import os
-import pipes
+import shlex
 import shutil
 import subprocess
 import sys
@@ -19,7 +19,7 @@ IS_MAC = sys.platform == "darwin"
 
 
 def call(*args, **kwargs):
-    print("Executing `%s`" % " ".join(pipes.quote(a) for a in args))
+    print("Executing `%s`" % " ".join(shlex.quote(a) for a in args))
     subprocess.check_call(args, **kwargs)
 
 

--- a/mozregression/main.py
+++ b/mozregression/main.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import atexit
 import os
-import pipes
+import shlex
 import sys
 
 import colorama
@@ -265,7 +265,7 @@ class Application(object):
             argv.append("--bad=%s" % handler.bad_revision)
 
         LOG.info("To resume, run:")
-        LOG.info(" ".join([pipes.quote(arg) for arg in argv]))
+        LOG.info(" ".join([shlex.quote(arg) for arg in argv]))
 
     def _on_exit_print_resume_info(self, handler):
         handler.print_range()


### PR DESCRIPTION
Python 3.13 removed the already deprecated "pipes" module from the standard library.
Some files were using the "quote" function from pipes, which prior to 3.13 was a re-export of a function with the same name in "shlex".

This change imports the shlex module directly.

https://github.com/python/cpython/blob/3.12/Lib/pipes.py#L66 https://docs.python.org/3/whatsnew/3.13.html