### PR TITLE
workflows: deprecate ubuntu-20.04 from workflow jobs (bug 1980503)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
@@ -87,8 +86,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
     env:
       DISPLAY: ":99.0"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- remove ubuntu-20.04 from build-and-test-linux-base
- also add ubuntu-24.04 to build-and-test-linux-gui

NOTE: lint issues will be fixed in #2018 