### PR TITLE
wizard: fix copy (bug 1986029)

### DIFF
--- a/gui/mozregui/wizard.py
+++ b/gui/mozregui/wizard.py
@@ -179,7 +179,7 @@ class ProfilePage(WizardPage):
     TITLE = "Profile selection"
     SUBTITLE = (
         "Choose a specific profile. You can choose an existing profile"
-        ", or let this blank to use a new one."
+        ", or leave this blank to use a new one."
     )
     FIELDS = {
         "profile": "profile_widget.line_edit",


### PR DESCRIPTION
The text 'let this blank' should say 'leave this blank' when choosing a profile