### PR TITLE
Support integration branch bisection for Fenix (Bug 1857026)

### DIFF
--- a/mozregression/fetch_build_info.py
+++ b/mozregression/fetch_build_info.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 
 import os
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from threading import Lock, Thread
 
@@ -32,37 +33,7 @@ class InfoFetcher(object):
         self.build_regex = re.compile(fetch_config.build_regex())
         self.build_info_regex = re.compile(fetch_config.build_info_regex())
 
-    def _update_build_info_from_txt(self, build_info):
-        LOG.debug("Update build info from {}".format(build_info))
-        if "build_txt_url" in build_info:
-            build_info.update(self._fetch_txt_info(build_info["build_txt_url"]))
-
-    def _fetch_txt_info(self, url):
-        """
-        Retrieve information from a build information txt file.
-
-        Returns a dict with keys repository and changeset if information
-        is found.
-        """
-        LOG.debug("Fetching txt info from {}".format(url))
-        data = {}
-        response = retry_get(url)
-        for line in response.text.splitlines():
-            if "/rev/" in line:
-                repository, changeset = line.split("/rev/")
-                data["repository"] = repository
-                data["changeset"] = changeset
-                break
-        if not data:
-            # the txt file could be in an old format:
-            # DATE CHANGESET
-            # we can try to extract that to get the changeset at least.
-            matched = re.match(r"^\d+ (\w+)$", response.text.strip())
-            if matched:
-                data["changeset"] = matched.group(1)
-        return data
-
-    def find_build_info(self, changeset_or_date, fetch_txt_info=True):
+    def find_build_info(self, changeset_or_date):
         """
         Abstract method to retrieve build information over the internet for
         one build.
@@ -172,9 +143,57 @@ class IntegrationInfoFetcher(InfoFetcher):
         )
 
 
+@dataclass
+class ChangesetInfo:
+    """
+    Result of resolving changeset info for a nightly build.
+
+    These are generated during the fetch process and then turned into a
+    `BuildInfo` before being consumed elsewhere in the system. Some sample
+    providers are included, but the fetch config's `get_nightly_changeset`
+    can provide other behaviours.
+    """
+
+    changeset: str = None
+    repo_url: str = None
+
+    @staticmethod
+    def from_nightly_txt(archive_urls):
+        """
+        Lookup changeset info from .txt file on archive server if exists.
+        """
+        if archive_urls.build_txt_url:
+            LOG.debug("Fetching txt info from {}".format(archive_urls.build_txt_url))
+
+            response = retry_get(archive_urls.build_txt_url)
+            for line in response.text.splitlines():
+                if "/rev/" in line:
+                    repo_url, changeset = line.split("/rev/")
+                    return ChangesetInfo(changeset, repo_url)
+
+            # the txt file could be in an old format:
+            # DATE CHANGESET
+            # we can try to extract that to get the changeset at least.
+            matched = re.match(r"^\d+ (\w+)$", response.text.strip())
+            if matched:
+                changeset = matched.group(1)
+                return ChangesetInfo(changeset)
+
+        return ChangesetInfo()
+
+
+@dataclass
+class ArchiveBuildUrls:
+    """Result of scraping build folder on archive server."""
+
+    build_url: str
+    build_txt_url: str
+
+
 class NightlyInfoFetcher(InfoFetcher):
     def __init__(self, fetch_config):
         InfoFetcher.__init__(self, fetch_config)
+
         self._cache_months = {}
         self._lock = Lock()
         self._fetch_lock = Lock()
@@ -183,34 +202,38 @@ class NightlyInfoFetcher(InfoFetcher):
         """
         Retrieve information from a build folder url.
 
-        Stores in a list the url index and a dict instance with keys
+        Stores in a list the url index and a ArchiveBuildUrls instance with
         build_url and build_txt_url if respectively a build file and a
         build info file are found for the url.
         """
         LOG.debug("Fetching build info from {}".format(url))
-        data = {}
+
         if not url.endswith("/"):
             url += "/"
-        links = url_links(url)
-        if not self.fetch_config.has_build_info:
-            links += url_links(self.fetch_config.get_nightly_info_url(url))
-        for link in links:
-            name = os.path.basename(link)
-            if "build_url" not in data and self.build_regex.match(name):
-                data["build_url"] = link
-            elif "build_txt_url" not in data and self.build_info_regex.match(name):
-                data["build_txt_url"] = link
-        if data:
-            # Check that we found all required data. The URL in build_url is
-            # required. build_txt_url is optional.
-            if "build_url" not in data:
-                raise BuildInfoNotFound(
-                    "Failed to find a build file in directory {} that "
-                    "matches regex '{}'".format(url, self.build_regex.pattern)
-                )
+        info_url = self.fetch_config.get_nightly_info_url(url)
+
+        build_urls = []
+        build_txt_urls = []
+        for folder in {url, info_url}:
+            for link in url_links(folder):
+                name = os.path.basename(link)
+                if self.build_regex.match(name):
+                    build_urls.append(link)
+                if self.build_info_regex.match(name):
+                    build_txt_urls.append(link)
+
+        if build_urls:
+            build = build_urls[0]
+            build_txt = build_txt_urls[0] if build_txt_urls else None
 
             with self._fetch_lock:
-                lst.append((index, data))
+                lst.append((index, ArchiveBuildUrls(build, build_txt)))
+        elif build_txt_urls:
+            raise BuildInfoNotFound(
+                "Failed to find a build file in directory {} that matches regex '{}'".format(
+                    url, self.build_regex.pattern
+                )
+            )
 
     def _get_month_links(self, url):
         with self._lock:
@@ -223,7 +246,7 @@ class NightlyInfoFetcher(InfoFetcher):
         Get the url list of the build folder for a given date.
 
         This methods needs to be thread-safe as it is used in
-        :meth:`NightlyBuildData.get_build_url`.
+        :meth:`find_build_info`.
         """
         LOG.debug("Get URLs for {}".format(date))
         url = self.fetch_config.get_nightly_base_url(date)
@@ -240,7 +263,7 @@ class NightlyInfoFetcher(InfoFetcher):
         matches.reverse()
         return matches
 
-    def find_build_info(self, date, fetch_txt_info=True, max_workers=2):
+    def find_build_info(self, date, max_workers=2):
         """
         Find build info for a nightly build, given a date.
 
@@ -274,16 +297,14 @@ class NightlyInfoFetcher(InfoFetcher):
                     thread.join(0.1)
             LOG.debug("got valid_builds %s" % valid_builds)
             if valid_builds:
-                infos = sorted(valid_builds, key=lambda b: b[0])[0][1]
-                if fetch_txt_info:
-                    self._update_build_info_from_txt(infos)
-
+                selection = sorted(valid_builds, key=lambda b: b[0])[0][1]
+                changeset = self.fetch_config.get_nightly_changeset(selection)
                 build_info = NightlyBuildInfo(
                     self.fetch_config,
-                    build_url=infos["build_url"],
+                    build_url=selection.build_url,
                     build_date=date,
-                    changeset=infos.get("changeset"),
-                    repo_url=infos.get("repository"),
+                    changeset=changeset.changeset,
+                    repo_url=changeset.repo_url,
                 )
                 break
             build_urls = build_urls[max_workers:]

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -130,7 +130,7 @@ class CommonConfig(object):
         self.processor = processor
         self.set_arch(arch)
         self.repo = None
-        self.set_build_type("opt")
+        self.set_build_type(self.BUILD_TYPES[0])
         self._used_build_index = 0
 
     @property
@@ -625,10 +625,6 @@ class FirefoxConfig(CommonConfig, FirefoxNightlyConfigMixin, FirefoxIntegrationC
         "shippable": ("opt", "pgo"),
         "opt": ("shippable", "pgo"),
     }
-
-    def __init__(self, os, bits, processor, arch):
-        super(FirefoxConfig, self).__init__(os, bits, processor, arch)
-        self.set_build_type("shippable")
 
     def build_regex(self):
         return (

--- a/mozregression/fetch_configs.py
+++ b/mozregression/fetch_configs.py
@@ -399,6 +399,9 @@ class ThunderbirdL10nNightlyConfigMixin(ThunderbirdNightlyConfigMixin):
             )
         return "comm-central-l10n"
 
+    def get_nightly_info_url(self, url):
+        return url.replace("-l10n/", "/")
+
 
 class FennecNightlyConfigMixin(NightlyConfigMixin):
     nightly_base_repo_name = "mobile"

--- a/mozregression/json_pushes.py
+++ b/mozregression/json_pushes.py
@@ -155,3 +155,24 @@ class JsonPushes(object):
                     "No pushes available for the date %s on %s." % (changeset, self.branch)
                 )
         return self.pushes(changeset=changeset, **kwargs)[0]
+
+    def push_by_timestamp(self, timestamp):
+        """
+        Returns a list of Push objects for a timestamp.
+
+        This will return at least one Push. In case of error it will raise
+        a MozRegressionError.
+        """
+
+        if not isinstance(timestamp, datetime.datetime):
+            raise TypeError()
+
+        # The server interprets these as exclusive ranges, so shift
+        # them each by the minimum time unit.
+        dt = datetime.timedelta(seconds=1)
+        kwargs = {
+            "startdate": str(timestamp - dt),
+            "enddate": str(timestamp + dt),
+        }
+
+        return self.pushes(**kwargs)

--- a/tests/unit/test_fetch_build_info.py
+++ b/tests/unit/test_fetch_build_info.py
@@ -212,6 +212,34 @@ class TestNightlyInfoFetcherL10N:
         assert result.repo_url == repo_url
 
 
+class TestFenixNightlyInfoFetch(unittest.TestCase):
+    def setUp(self):
+        self.fetch_config = fetch_configs.create_config("fenix", None, None, None, "arm64-v8a")
+        self.info_fetcher = fetch_build_info.NightlyInfoFetcher(self.fetch_config)
+
+    @patch("mozregression.fetch_build_info.url_links")
+    def test__find_build_info_from_url(self, url_links):
+        """Test that _fetch_build_info_from_url returns ArchiveBuildUrls for Fenix builds."""
+        build_folder = "2026-01-01-09-03-33-fenix-147.0a1-android-arm64-v8a"
+        build_file = "fenix-147.0a1.multi.android-arm64-v8a.apk"
+        build_url = f"http://foo/{build_folder}/"
+
+        url_links.return_value = [build_url + build_file]
+
+        builds = []
+        self.info_fetcher._fetch_build_info_from_url(build_url, 0, builds)
+
+        # Verify we got one build
+        self.assertEqual(len(builds), 1)
+
+        # Verify the structure: (index, ArchiveBuildUrls)
+        index, archive_urls = builds[0]
+        self.assertEqual(index, 0)
+        self.assertIsInstance(archive_urls, ArchiveBuildUrls)
+        self.assertEqual(archive_urls.build_url, build_url + build_file)
+        self.assertIsNone(archive_urls.build_txt_url)  # Fenix doesn't have .txt files
+
+
 class TestIntegrationInfoFetcher(unittest.TestCase):
     def setUp(self):
         self.fetch_config = fetch_configs.create_config("firefox", "linux", 64, "x86_64")

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -320,6 +320,41 @@ class TestFenixConfig(unittest.TestCase):
     def setUp(self):
         self.conf = create_config("fenix", None, None, None, "arm64-v8a")
 
+    def test_get_nightly_changeset_uses_pushlog(self):
+        """Test that get_nightly_changeset for Fenix uses JsonPushes API."""
+        from unittest.mock import Mock, patch
+
+        from mozregression.fetch_build_info import ArchiveBuildUrls, ChangesetInfo
+
+        # Create a sample build URL with timestamp
+        build_url = (
+            "https://archive.mozilla.org/pub/fenix/nightly/2025/12/"
+            "2025-12-01-10-27-59-fenix-147.0a1-android-arm64-v8a/"
+            "fenix-147.0a1.multi.android-arm64-v8a.apk"
+        )
+        archive_urls = ArchiveBuildUrls(build_url, None)
+
+        # Mock JsonPushes to avoid network calls
+        with patch("mozregression.fetch_build_info.JsonPushes") as MockJsonPushes:
+            mock_jpushes_instance = Mock()
+            mock_jpushes_instance.repo_url = "https://hg.mozilla.org/mozilla-central"
+            mock_push = Mock()
+            mock_push.changeset = "abc123def456"
+            mock_jpushes_instance.push_by_timestamp.return_value = [mock_push]
+            MockJsonPushes.return_value = mock_jpushes_instance
+
+            # Call get_nightly_changeset
+            result = self.conf.get_nightly_changeset(archive_urls)
+
+            # Verify the result
+            assert isinstance(result, ChangesetInfo)
+            assert result.changeset == "abc123def456"
+            assert result.repo_url == "https://hg.mozilla.org/mozilla-central"
+
+            # Verify JsonPushes was called
+            MockJsonPushes.assert_called_once_with(branch="mozilla-central")
+            mock_jpushes_instance.push_by_timestamp.assert_called_once()
+
     def test_build_regex(self):
         assert re.match(self.conf.build_regex(), "fenix-148.0a1.multi.android-arm64-v8a.apk")
         assert not re.match(
@@ -641,6 +676,18 @@ def test_jsshell_aarch64_build_regex():
 
     conf = create_config("jsshell", "win", 64, "aarch64", arch="x86_64")
     assert re.match(conf.build_regex(), "jsshell-win64-x86_64.zip")
+
+
+def test_nightly_timestamp_parse():
+    conf = create_config("fenix", None, None, None, "arm64-v8a")
+    build_url = (
+        "https://archive.mozilla.org/pub/fenix/nightly/2025/12/"
+        "2025-12-01-10-27-59-fenix-147.0a1-android-arm64-v8a/"
+        "fenix-147.0a1.multi.android-arm64-v8a.apk"
+    )
+    expected_dt = datetime.datetime(2025, 12, 1, 10, 27, 59)
+
+    assert conf.get_nightly_timestamp_from_url(build_url) == expected_dt
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -316,6 +316,17 @@ class TestGVEConfig(unittest.TestCase):
         assert self.conf.build_type == "shippable"
 
 
+class TestFenixConfig(unittest.TestCase):
+    def setUp(self):
+        self.conf = create_config("fenix", None, None, None, "arm64-v8a")
+
+    def test_build_regex(self):
+        assert re.match(self.conf.build_regex(), "fenix-148.0a1.multi.android-arm64-v8a.apk")
+        assert not re.match(
+            self.conf.build_info_regex(), "fenix-148.0a1.multi.android-arm64-v8a.txt"
+        )
+
+
 class TestGetBuildUrl(unittest.TestCase):
     def test_for_linux(self):
         self.assertEqual(

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -303,12 +303,12 @@ class TestGVEConfig(unittest.TestCase):
         self.conf = create_config("gve", "linux", 64, None)
 
     def test_fallbacking(self):
-        assert self.conf.build_type == "opt"
-        self.conf._inc_used_build()
         assert self.conf.build_type == "shippable"
+        self.conf._inc_used_build()
+        assert self.conf.build_type == "opt"
         # Check we wrap
         self.conf._inc_used_build()
-        assert self.conf.build_type == "opt"
+        assert self.conf.build_type == "shippable"
 
 
 class TestGetBuildUrl(unittest.TestCase):
@@ -481,7 +481,7 @@ CHSET12 = "47856a214918"
             None,
             None,
             TIMESTAMP_FENNEC_API_15 - 1,
-            "gecko.v2.mozilla-central.revision.%s.mobile.android-api-11-opt" % CHSET,
+            "gecko.v2.mozilla-central.shippable.revision.%s.mobile.android-api-11-opt" % CHSET,
         ),
         (
             "fennec",
@@ -490,7 +490,7 @@ CHSET12 = "47856a214918"
             None,
             None,
             TIMESTAMP_FENNEC_API_15,
-            "gecko.v2.mozilla-central.revision.%s.mobile.android-api-15-opt" % CHSET,
+            "gecko.v2.mozilla-central.shippable.revision.%s.mobile.android-api-15-opt" % CHSET,
         ),
         (
             "fennec",
@@ -499,7 +499,7 @@ CHSET12 = "47856a214918"
             None,
             None,
             TIMESTAMP_FENNEC_API_16,
-            "gecko.v2.mozilla-central.revision.%s.mobile.android-api-16-opt" % CHSET,
+            "gecko.v2.mozilla-central.shippable.revision.%s.mobile.android-api-16-opt" % CHSET,
         ),
         # thunderbird
         (

--- a/tests/unit/test_fetch_configs.py
+++ b/tests/unit/test_fetch_configs.py
@@ -278,6 +278,11 @@ class TestExtendedAndroidConfig:
             assert "mozilla-central-android-api-15" in regex
             regex = conf.get_nightly_repo_regex(datetime.date(2017, 8, 30))
             assert "mozilla-central-android-api-16" in regex
+        elif app_name in ["fenix", "focus"]:
+            conf = create_config(app_name, None, None, None, "arm64-v8a")
+            date = datetime.date(2022, 1, 1)
+            regex = conf.get_nightly_repo_regex(date)
+            assert regex == f"/{date.isoformat()}-[\\d-]+{app_name}-[^-]+-android-arm64-v8a/$"
         else:
             conf = create_config(app_name, "linux", 64, None)
             date = datetime.date(2023, 1, 1)


### PR DESCRIPTION
This improves support of Fenix and Focus by supporting bisection without the presence of build-info txt files on archive.mozilla.org. Instead of the text files, I use the existing JsonPushes modules to determine changeset based on build timestamp extracted from path names on archive.mozilla.org. With some small fixes to the FenixConfig, it is easy to support the Integration mixin and get proper pushlog support.

The current fenix builds use taskcluster routes called 'nightly' or 'nightly-simulation' that are roughly what we'd consider to be 'shippable' builds on desktop.