### PR TITLE
releases: sort output of `--list-releases` (Bug 2015892)

### DIFF
--- a/mozregression/releases.py
+++ b/mozregression/releases.py
@@ -136,7 +136,9 @@ def formatted_valid_release_dates():
     the valid release dates.
     """
     message = "Valid releases: \n"
-    for key, value in releases().items():
+    releases_descending = list(releases().items())
+    releases_descending.sort(reverse=True, key=lambda t: t[0])
+    for key, value in releases_descending:
         message += "% 3s: %s\n" % (key, value)
 
     return message


### PR DESCRIPTION
`--list-releases` doesn't have a specified order for its output. It seems like this misses an opportunity to help a user find a release they actually want; I've never seen a useful version index without some form of sorting. Apply sorting by reverse order, under the assumption that the user will likely be most interested in the most recent releases.