### PR TITLE
launchers: Handle existing distribution directory in Firefox builds (bug 2015791)

### DIFF
--- a/mozregression/launchers.py
+++ b/mozregression/launchers.py
@@ -250,7 +250,7 @@ class MozRunnerLauncher(Launcher):
             # we need policies.json in:
             #     PackageName.app/Contents/Resources/distribution
             installdir = os.path.normpath(os.path.join(installdir, "..", "Resources"))
-        os.makedirs(os.path.join(installdir, "distribution"))
+        os.makedirs(os.path.join(installdir, "distribution"), exist_ok=True)
         policyFile = os.path.join(installdir, "distribution", "policies.json")
         with open(policyFile, "w") as fp:
             json.dump(updatePolicy, fp, indent=2)


### PR DESCRIPTION
See also: https://bugzilla.mozilla.org/show_bug.cgi?id=2010200